### PR TITLE
Fix typing on TestCreatedParams

### DIFF
--- a/src/json_protocol.jl
+++ b/src/json_protocol.jl
@@ -124,7 +124,7 @@ const notficiationTypeAppendOutput = NotificationType("appendOutput", AppendOutp
     packageUri::Union{Missing,String}
     projectUri::Union{Missing,String}
     coverage::Bool
-    env::Dict{String,String}
+    env::Dict{String,Union{String, Nothing}}
 end
 
 const notificationTypeTestProcessCreated = NotificationType("testProcessCreated", TestProcessCreatedParams)


### PR DESCRIPTION
The `env` entry in `TestItemCreatedParams` is derived from a `TestProfile.julia_env`, which is typed as a `Dict{String, Union{String, Nothing}}`. The existing `env` definition omits the union and just expects a dict from strings to strings. This loosens that requirement to align with the `TestProfile.julia_env`