### PR TITLE
S3: skip, per-item perf stats and setup output attribution

### DIFF
--- a/src/json_protocol.jl
+++ b/src/json_protocol.jl
@@ -38,6 +38,9 @@ end
     code::String
     codeLine::Int
     codeColumn::Int
+    # The `skip` kwarg: `true`/`false` for a literal, or the source text of an expression the
+    # *test process* evaluates immediately before the item would run. Absent means `false`.
+    optionSkip::Union{Missing,Bool,String}
 end
 
 @dict_readable struct TestSetupDetail <: JSONRPC.Outbound
@@ -105,11 +108,23 @@ end
 
 const notficiationTypeTestItemStarted = NotificationType("testItemStarted", TestItemStartedParams)
 
+# Execution statistics for one test item. Every field is optional: the compile timings in
+# particular rely on Julia internals that not every version the test process supports has.
+@dict_readable struct PerfStatsParams <: Outbound
+    elapsed::Union{Missing,Float64}         # milliseconds
+    bytes::Union{Missing,Int}
+    allocs::Union{Missing,Int}
+    gctime::Union{Missing,Float64}          # milliseconds
+    compileTime::Union{Missing,Float64}     # milliseconds
+    recompileTime::Union{Missing,Float64}   # milliseconds
+end
+
 @dict_readable struct TestItemErroredParams <: Outbound
     testRunId::String
     testItemId::String
     messages::Vector{TestMessage}
     duration::Union{Missing,Float64}
+    perf::Union{Missing,PerfStatsParams}
 end
 const notficiationTypeTestItemErrored = NotificationType("testItemErrored", TestItemErroredParams)
 
@@ -118,6 +133,7 @@ const notficiationTypeTestItemErrored = NotificationType("testItemErrored", Test
     testItemId::String
     messages::Vector{TestMessage}
     duration::Union{Missing,Float64}
+    perf::Union{Missing,PerfStatsParams}
 end
 const notficiationTypeTestItemFailed = NotificationType("testItemFailed", TestItemFailedParams)
 
@@ -125,10 +141,19 @@ const notficiationTypeTestItemFailed = NotificationType("testItemFailed", TestIt
     testRunId::String
     testItemId::String
     duration::Union{Missing,Float64}
+    perf::Union{Missing,PerfStatsParams}
 end
 
 const notficiationTypeTestItemPassed = NotificationType("testItemPassed", TestItemPassedParams)
-const notficiationTypeTestItemSkipped = NotificationType("testItemSkipped", @NamedTuple{testRunId::String,testItemId::String})
+
+@dict_readable struct TestItemSkippedParams <: Outbound
+    testRunId::String
+    testItemId::String
+    # Source text of the `skip` expression that evaluated to `true`, when there was one.
+    reason::Union{Missing,String}
+end
+
+const notficiationTypeTestItemSkipped = NotificationType("testItemSkipped", TestItemSkippedParams)
 
 @dict_readable struct AppendOutputParams <: Outbound
     testRunId::String

--- a/src/jsonrpctestitemcontroller.jl
+++ b/src/jsonrpctestitemcontroller.jl
@@ -24,6 +24,18 @@ function _to_wire_messages(messages::Vector{TestMessage})
     ]
 end
 
+function _to_wire_perf(perf::Union{Nothing,PerfStats})
+    perf === nothing && return missing
+    return TestItemControllerProtocol.PerfStatsParams(
+        elapsed = something(perf.elapsed, missing),
+        bytes = something(perf.bytes, missing),
+        allocs = something(perf.allocs, missing),
+        gctime = something(perf.gctime, missing),
+        compileTime = something(perf.compile_time, missing),
+        recompileTime = something(perf.recompile_time, missing),
+    )
+end
+
 function _to_wire_coverage(coverage::Vector{FileCoverage})
     return TestItemControllerProtocol.FileCoverage[
         TestItemControllerProtocol.FileCoverage(
@@ -89,35 +101,42 @@ mutable struct JSONRPCTestItemController
                     testItemId=testitem_id
                 )
             ),
-            on_testitem_passed = (testrun_id, testitem_id, test_env_id, duration) -> _safe_send(
+            on_testitem_passed = (testrun_id, testitem_id, test_env_id, duration, perf=nothing) -> _safe_send(
                 TestItemControllerProtocol.notficiationTypeTestItemPassed,
                 TestItemControllerProtocol.TestItemPassedParams(
                     testRunId=testrun_id,
                     testItemId=testitem_id,
-                    duration=duration
+                    duration=duration,
+                    perf=_to_wire_perf(perf)
                 )
             ),
-            on_testitem_failed = (testrun_id, testitem_id, test_env_id, messages, duration) -> _safe_send(
+            on_testitem_failed = (testrun_id, testitem_id, test_env_id, messages, duration, perf=nothing) -> _safe_send(
                 TestItemControllerProtocol.notficiationTypeTestItemFailed,
                 TestItemControllerProtocol.TestItemFailedParams(
                     testRunId=testrun_id,
                     testItemId=testitem_id,
                     messages=_to_wire_messages(messages),
-                    duration=something(duration, missing)
+                    duration=something(duration, missing),
+                    perf=_to_wire_perf(perf)
                 )
             ),
-            on_testitem_errored = (testrun_id, testitem_id, test_env_id, messages, duration) -> _safe_send(
+            on_testitem_errored = (testrun_id, testitem_id, test_env_id, messages, duration, perf=nothing) -> _safe_send(
                 TestItemControllerProtocol.notficiationTypeTestItemErrored,
                 TestItemControllerProtocol.TestItemErroredParams(
                     testRunId=testrun_id,
                     testItemId=testitem_id,
                     messages=_to_wire_messages(messages),
-                    duration=something(duration, missing)
+                    duration=something(duration, missing),
+                    perf=_to_wire_perf(perf)
                 )
             ),
-            on_testitem_skipped = (testrun_id, testitem_id, test_env_id) -> _safe_send(
+            on_testitem_skipped = (testrun_id, testitem_id, test_env_id, reason=nothing) -> _safe_send(
                 TestItemControllerProtocol.notficiationTypeTestItemSkipped,
-                (testRunId=testrun_id, testItemId=testitem_id)
+                TestItemControllerProtocol.TestItemSkippedParams(
+                    testRunId=testrun_id,
+                    testItemId=testitem_id,
+                    reason=something(reason, missing)
+                )
             ),
             on_append_output = (testrun_id, testitem_id, test_env_id, output) -> _safe_send(
                 TestItemControllerProtocol.notficiationTypeAppendOutput,
@@ -209,6 +228,7 @@ function create_testrun_request(params::TestItemControllerProtocol.CreateTestRun
             i.code,
             i.codeLine,
             i.codeColumn,
+            i.optionSkip === missing ? false : i.optionSkip,
         )
         for i in params.testItems
     ]

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -83,7 +83,10 @@ struct TestItemPassedMsg <: ReactorMessage
     testitem_id::String
     duration::Float64
     coverage::Union{Nothing,Vector{Any}}
+    perf::Union{Nothing,PerfStats}
 end
+TestItemPassedMsg(testrun_id, testprocess_id, testitem_id, duration, coverage) =
+    TestItemPassedMsg(testrun_id, testprocess_id, testitem_id, duration, coverage, nothing)
 
 struct TestItemFailedMsg <: ReactorMessage
     testrun_id::String
@@ -91,7 +94,10 @@ struct TestItemFailedMsg <: ReactorMessage
     testitem_id::String
     messages::Vector{Any}
     duration::Union{Nothing,Float64}
+    perf::Union{Nothing,PerfStats}
 end
+TestItemFailedMsg(testrun_id, testprocess_id, testitem_id, messages, duration) =
+    TestItemFailedMsg(testrun_id, testprocess_id, testitem_id, messages, duration, nothing)
 
 struct TestItemErroredMsg <: ReactorMessage
     testrun_id::String
@@ -99,12 +105,35 @@ struct TestItemErroredMsg <: ReactorMessage
     testitem_id::String
     messages::Vector{Any}
     duration::Union{Nothing,Float64}
+    perf::Union{Nothing,PerfStats}
 end
+TestItemErroredMsg(testrun_id, testprocess_id, testitem_id, messages, duration) =
+    TestItemErroredMsg(testrun_id, testprocess_id, testitem_id, messages, duration, nothing)
 
 struct TestItemSkippedStolenMsg <: ReactorMessage
     testrun_id::String
     testprocess_id::String
     testitem_id::String
+end
+
+# The test process declined to run an item because its `skip` expression was true. Nothing
+# to do with `TestItemSkippedStolenMsg`, which reports an item another process claimed.
+struct TestItemSkippedMsg <: ReactorMessage
+    testrun_id::String
+    testprocess_id::String
+    testitem_id::String
+    reason::Union{Nothing,String}
+end
+
+# A `@testmodule`/`@testsnippet` was evaluated on a test process. Process-level rather than
+# run-level: the result stays valid for as long as the process caches the setup, including
+# across runs.
+struct TestSetupEvaluatedMsg <: ReactorMessage
+    testprocess_id::String
+    package_uri::String
+    name::String
+    duration::Union{Nothing,Float64}
+    output::String
 end
 
 struct AppendOutputMsg <: ReactorMessage

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -761,7 +761,7 @@ function handle!(c::TestItemController, msg::TestItemPassedMsg)
         _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
 
         push!(tr.reported_items, msg.testitem_id)
-        _notify_testitem_passed(c.callbacks, msg.testrun_id, msg.testitem_id, test_env_id, msg.duration)
+        _notify_testitem_passed(c.callbacks, msg.testrun_id, msg.testitem_id, test_env_id, msg.duration, msg.perf)
 
         if msg.coverage !== nothing
             append!(tr.coverage, map(i -> CoverageTools.FileCoverage(uri2filepath(i.uri), "", i.coverage), msg.coverage))
@@ -842,7 +842,8 @@ function handle!(c::TestItemController, msg::TestItemFailedMsg)
                     _convert_stack_trace(i.stackTrace),
                 ) for i in msg.messages
             ],
-            msg.duration
+            msg.duration,
+            msg.perf
         )
     else
         _log_unexpected_missing_work(tr, msg.testitem_id, msg.testprocess_id, test_env_id, "failed")
@@ -908,7 +909,8 @@ function handle!(c::TestItemController, msg::TestItemErroredMsg)
                     _convert_stack_trace(i.stackTrace),
                 ) for i in msg.messages
             ],
-            msg.duration
+            msg.duration,
+            msg.perf
         )
     else
         _log_unexpected_missing_work(tr, msg.testitem_id, msg.testprocess_id, test_env_id, "errored")
@@ -944,6 +946,72 @@ function handle!(c::TestItemController, msg::TestItemSkippedStolenMsg)
 
     _check_stealing!(c, tr, msg.testprocess_id)
     _check_testrun_complete!(c, tr)
+    return false
+end
+
+function handle!(c::TestItemController, msg::TestItemSkippedMsg)
+    if !haskey(c.test_runs, msg.testrun_id)
+        return false
+    end
+    tr = c.test_runs[msg.testrun_id]
+    if state(tr.fsm) in (TestRunCancelled, TestRunCompleted)
+        return false
+    end
+
+    # Cancel timeout
+    if haskey(c.test_processes, msg.testprocess_id)
+        _cancel_timeout!(c.test_processes[msg.testprocess_id])
+    end
+
+    # Handle stolen tracking
+    stolen_idx = findfirst(isequal(msg.testitem_id), get(tr.stolen_ids_by_proc, msg.testprocess_id, String[]))
+    if stolen_idx !== nothing
+        deleteat!(tr.stolen_ids_by_proc[msg.testprocess_id], stolen_idx)
+    end
+
+    # Discard the result if another process owns this item — see `_owns_testitem`.
+    if !_owns_testitem(tr, msg.testprocess_id, msg.testitem_id)
+        _log_discarded_result(msg.testitem_id, msg.testprocess_id, "skipped")
+        _check_stealing!(c, tr, msg.testprocess_id)
+        _check_testrun_complete!(c, tr)
+        return false
+    end
+
+    # Resolve test_env_id
+    test_env_id = if haskey(c.test_processes, msg.testprocess_id)
+        _resolve_test_env_id(tr, c.test_processes[msg.testprocess_id].env)
+    else
+        first(tr.test_environments).id
+    end
+
+    work_key = (msg.testitem_id, test_env_id)
+    if haskey(tr.remaining_work, work_key)
+        delete!(tr.remaining_work, work_key)
+        _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
+
+        push!(tr.reported_items, msg.testitem_id)
+        _notify_testitem_skipped(c.callbacks, msg.testrun_id, msg.testitem_id, test_env_id, msg.reason)
+    else
+        _log_unexpected_missing_work(tr, msg.testitem_id, msg.testprocess_id, test_env_id, "skipped")
+        _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
+    end
+
+    _check_stealing!(c, tr, msg.testprocess_id)
+    _check_testrun_complete!(c, tr)
+    return false
+end
+
+# Records what a setup cost and printed on this process. The test process replays the output
+# onto every item that declares the setup itself; what the controller keeps this for is the
+# cost model, and it therefore survives for as long as the process caches the setup.
+function handle!(c::TestItemController, msg::TestSetupEvaluatedMsg)
+    ps = get(c.test_processes, msg.testprocess_id, nothing)
+    if ps === nothing
+        return false
+    end
+
+    ps.loaded_setups[(msg.package_uri, msg.name)] = (output=msg.output, duration=msg.duration)
+
     return false
 end
 
@@ -1931,6 +1999,12 @@ function _configure_testrun!(c::TestItemController, ps::TestProcessState)
     end
 end
 
+# The wire format carries the `skip` kwarg as source text, because the test process is what
+# evaluates it. A literal is sent as `"true"`/`"false"` rather than being resolved here, so
+# the test process has a reason string to report either way; `false` is left off entirely.
+_skip_source(option_skip::Bool) = option_skip ? "true" : missing
+_skip_source(option_skip::AbstractString) = String(option_skip)
+
 function _send_run_testitems!(c::TestItemController, ps::TestProcessState, items)
     if ps.endpoint === nothing || !isopen(ps.endpoint)
         @warn "Cannot send test items: process has no endpoint" testprocess_id=ps.id
@@ -1961,6 +2035,7 @@ function _send_run_testitems!(c::TestItemController, ps::TestProcessState, items
                         line = i.code_line,
                         column = i.code_column,
                         code = i.code,
+                        skip = _skip_source(i.option_skip),
                     ) for i in items
                 ],
             )

--- a/src/testprocess.jl
+++ b/src/testprocess.jl
@@ -12,21 +12,21 @@ JSONRPC.@message_dispatcher dispatch_testprocess_msg begin
         reactor_channel, ps = ctx
         testrun_id = ps.testrun_id
         if testrun_id !== nothing
-            put!(reactor_channel, TestItemPassedMsg(testrun_id, ps.id, params.testItemId, params.duration, coalesce(params.coverage, nothing)))
+            put!(reactor_channel, TestItemPassedMsg(testrun_id, ps.id, params.testItemId, params.duration, coalesce(params.coverage, nothing), _convert_perf_stats(params.perf)))
         end
     end
     TestItemServerProtocol.failed_notification_type => (params, ctx) -> begin
         reactor_channel, ps = ctx
         testrun_id = ps.testrun_id
         if testrun_id !== nothing
-            put!(reactor_channel, TestItemFailedMsg(testrun_id, ps.id, params.testItemId, params.messages, coalesce(params.duration, nothing)))
+            put!(reactor_channel, TestItemFailedMsg(testrun_id, ps.id, params.testItemId, params.messages, coalesce(params.duration, nothing), _convert_perf_stats(params.perf)))
         end
     end
     TestItemServerProtocol.errored_notification_type => (params, ctx) -> begin
         reactor_channel, ps = ctx
         testrun_id = ps.testrun_id
         if testrun_id !== nothing
-            put!(reactor_channel, TestItemErroredMsg(testrun_id, ps.id, params.testItemId, params.messages, coalesce(params.duration, nothing)))
+            put!(reactor_channel, TestItemErroredMsg(testrun_id, ps.id, params.testItemId, params.messages, coalesce(params.duration, nothing), _convert_perf_stats(params.perf)))
         end
     end
     TestItemServerProtocol.skipped_stolen_notification_type => (params, ctx) -> begin
@@ -36,6 +36,29 @@ JSONRPC.@message_dispatcher dispatch_testprocess_msg begin
             put!(reactor_channel, TestItemSkippedStolenMsg(testrun_id, ps.id, params.testItemId))
         end
     end
+    TestItemServerProtocol.skipped_notification_type => (params, ctx) -> begin
+        reactor_channel, ps = ctx
+        testrun_id = ps.testrun_id
+        if testrun_id !== nothing
+            put!(reactor_channel, TestItemSkippedMsg(testrun_id, ps.id, params.testItemId, coalesce(params.reason, nothing)))
+        end
+    end
+    TestItemServerProtocol.setup_evaluated_notification_type => (params, ctx) -> begin
+        reactor_channel, ps = ctx
+        put!(reactor_channel, TestSetupEvaluatedMsg(ps.id, params.packageUri, params.name, coalesce(params.durationMs, nothing), coalesce(params.output, "")))
+    end
+end
+
+function _convert_perf_stats(perf::Union{Missing,TestItemServerProtocol.PerfStatsParams})
+    perf === missing && return nothing
+    return PerfStats(
+        coalesce(perf.elapsed, nothing),
+        coalesce(perf.bytes, nothing),
+        coalesce(perf.allocs, nothing),
+        coalesce(perf.gctime, nothing),
+        coalesce(perf.compile_time, nothing),
+        coalesce(perf.recompile_time, nothing),
+    )
 end
 
 function _truncate_for_log(s::AbstractString; max_bytes::Int=8192)

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -104,6 +104,27 @@
         return (items=items, setups=setups, package_name=pkg_name, package_uri=pkg_uri, project_uri=proj_uri, env_content_hash=content_hash)
     end
 
+    # Returns a copy of `item` carrying a `skip` option. Discovery does not supply one yet —
+    # `option_skip` reaches `TestItemDetail` from JuliaWorkspaces, which is stream S1 — so
+    # tests for the test-process side of `skip` set it here instead.
+    function with_skip(item::TestItemDetail, skip::Union{Bool,String})
+        return TestItemDetail(
+            item.id,
+            item.uri,
+            item.label,
+            item.package_name,
+            item.package_uri,
+            item.option_default_imports,
+            item.test_setups,
+            item.line,
+            item.column,
+            item.code,
+            item.code_line,
+            item.code_column,
+            skip,
+        )
+    end
+
     function make_test_environment(; mode="Run", julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing)
         TestEnvironment(
             "test-env-1",
@@ -134,11 +155,21 @@
         run_testrun(items, setups; _env_kwargs(discovered)..., kwargs...)
     end
 
-    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=300, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing)
+    # `n_runs > 1` executes that many test runs back-to-back against **one** controller, so
+    # the second run gets the pooled, already-warm test process of the first. `runs` in the
+    # returned value holds the per-run events and output; `events`/`outputs` are the union
+    # across runs, which is what a single-run caller wants.
+    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=300, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1)
         events = NamedTuple[]
         events_lock = ReentrantLock()
         push_event!(e) = lock(events_lock) do
             push!(events, e)
+        end
+
+        outputs = Dict{Union{Nothing,String},String}()
+        outputs_lock = ReentrantLock()
+        push_output!(item_id, output) = lock(outputs_lock) do
+            outputs[item_id] = get(outputs, item_id, "") * output
         end
 
         process_events = NamedTuple[]
@@ -149,11 +180,11 @@
 
         callbacks = ControllerCallbacks(
             on_testitem_started = (run_id, item_id, test_env_id) -> push_event!((event=:started, testrun_id=run_id, testitem_id=item_id)),
-            on_testitem_passed = (run_id, item_id, test_env_id, duration) -> push_event!((event=:passed, testrun_id=run_id, testitem_id=item_id, duration=duration)),
-            on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> push_event!((event=:failed, testrun_id=run_id, testitem_id=item_id, messages=messages, duration=duration)),
-            on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> push_event!((event=:errored, testrun_id=run_id, testitem_id=item_id, messages=messages, duration=duration)),
-            on_testitem_skipped = (run_id, item_id, test_env_id) -> push_event!((event=:skipped, testrun_id=run_id, testitem_id=item_id)),
-            on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
+            on_testitem_passed = (run_id, item_id, test_env_id, duration, perf=nothing) -> push_event!((event=:passed, testrun_id=run_id, testitem_id=item_id, duration=duration, perf=perf)),
+            on_testitem_failed = (run_id, item_id, test_env_id, messages, duration, perf=nothing) -> push_event!((event=:failed, testrun_id=run_id, testitem_id=item_id, messages=messages, duration=duration, perf=perf)),
+            on_testitem_errored = (run_id, item_id, test_env_id, messages, duration, perf=nothing) -> push_event!((event=:errored, testrun_id=run_id, testitem_id=item_id, messages=messages, duration=duration, perf=perf)),
+            on_testitem_skipped = (run_id, item_id, test_env_id, reason=nothing) -> push_event!((event=:skipped, testrun_id=run_id, testitem_id=item_id, reason=reason)),
+            on_append_output = (run_id, item_id, test_env_id, output) -> push_output!(item_id, output),
             on_attach_debugger = (run_id, pipe_name) -> nothing,
             on_process_created = (id, test_env_id) -> push_process_event!((event=:process_created, id=id, test_env_id=test_env_id)),
 
@@ -164,7 +195,6 @@
 
         controller = TestItemController(callbacks; log_level=log_level)
         test_env = make_test_environment(; mode=mode, julia_cmd=julia_cmd, julia_args=julia_args, package_name=package_name, package_uri=package_uri, project_uri=project_uri, env_content_hash=env_content_hash)
-        testrun_id = string(UUIDs.uuid4())
 
         # Build work units from items
         work_units = [TestRunItem(item.id, test_env.id, get(item_timeouts, item.id, nothing), log_level) for item in items]
@@ -176,45 +206,64 @@
         end
 
         coverage_result = nothing
-        testrun_task = @async try
-            coverage_result = execute_testrun(
-                controller,
-                testrun_id,
-                [test_env],
-                items,
-                work_units,
-                setups,
-                max_procs,
-                nothing;  # token
-                coverage_root_uris=coverage_root_uris
-            )
-        catch err
-            @error "Test run error" exception=(err, catch_backtrace())
-        end
+        runs = NamedTuple[]
 
-        # Wait for test run with timeout
-        timed_out = Ref(false)
-        timer = Timer(timeout)
-        @async begin
-            wait(timer)
-            if !istaskdone(testrun_task)
-                timed_out[] = true
-                @warn "Test run timed out after $(timeout)s, shutting down"
-                shutdown(controller)
+        for run_idx in 1:n_runs
+            events_before = length(events)
+            outputs_before = lock(outputs_lock) do
+                copy(outputs)
             end
-        end
 
-        wait(testrun_task)
-        close(timer)
+            testrun_id = string(UUIDs.uuid4())
+
+            testrun_task = @async try
+                coverage_result = execute_testrun(
+                    controller,
+                    testrun_id,
+                    [test_env],
+                    items,
+                    work_units,
+                    setups,
+                    max_procs,
+                    nothing;  # token
+                    coverage_root_uris=coverage_root_uris
+                )
+            catch err
+                @error "Test run error" exception=(err, catch_backtrace())
+            end
+
+            # Wait for test run with timeout
+            timed_out = Ref(false)
+            timer = Timer(timeout)
+            @async begin
+                wait(timer)
+                if !istaskdone(testrun_task)
+                    timed_out[] = true
+                    @warn "Test run timed out after $(timeout)s, shutting down"
+                    shutdown(controller)
+                end
+            end
+
+            wait(testrun_task)
+            close(timer)
+
+            if timed_out[]
+                shutdown(controller)
+                wait(controller_task)
+                error("run_testrun timed out after $(timeout)s")
+            end
+
+            run_events = events[events_before+1:end]
+            run_outputs = lock(outputs_lock) do
+                Dict(k => v[length(get(outputs_before, k, ""))+1:end] for (k, v) in outputs)
+            end
+            push!(runs, (testrun_id=testrun_id, events=run_events, outputs=run_outputs))
+        end
 
         shutdown(controller)
         wait(controller_task)
 
-        if timed_out[]
-            error("run_testrun timed out after $(timeout)s")
-        end
-
-        return (events=events, process_events=process_events, coverage=coverage_result)
+        return (events=events, process_events=process_events, coverage=coverage_result, outputs=outputs, runs=runs)
     end
 
     import UUIDs

--- a/test/test_worker_execution.jl
+++ b/test/test_worker_execution.jl
@@ -1,0 +1,240 @@
+@testitem "Skip by literal" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = [TestHelpers.with_skip(discovered.items[1], true)]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    skipped_events = filter(e -> e.event == :skipped, result.events)
+    @test length(skipped_events) == 1
+    @test skipped_events[1].reason == "true"
+    @test isempty(filter(e -> e.event in (:passed, :failed, :errored), result.events))
+end
+
+@testitem "Skip by literal false runs the item" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = [TestHelpers.with_skip(discovered.items[1], false)]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    @test isempty(filter(e -> e.event == :skipped, result.events))
+    @test length(filter(e -> e.event in (:passed, :failed), result.events)) == 1
+end
+
+@testitem "Skip by expression" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    # An expression only the test process can answer, which is the whole point of evaluating
+    # `skip` there rather than on the controller.
+    items = [TestHelpers.with_skip(discovered.items[1], "VERSION >= v\"1.0\"")]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    skipped_events = filter(e -> e.event == :skipped, result.events)
+    @test length(skipped_events) == 1
+    @test skipped_events[1].reason == "VERSION >= v\"1.0\""
+end
+
+@testitem "Skip expression source text is re-parenthesized" setup=[TestHelpers] begin
+    # JuliaSyntax records parentheses as trivia, so `skip=(a ? b : c)` reaches the test
+    # process as `a ? b : c` with the parentheses gone. Spliced in bare, the surrounding
+    # context reassociates it; the test process therefore always re-parenthesizes.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    # `false ? error("boom") : true` is `true` when parsed as one expression, and a parse
+    # error or a thrown `error` under any reassociation.
+    items = [TestHelpers.with_skip(discovered.items[1], "false ? error(\"boom\") : true")]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    skipped_events = filter(e -> e.event == :skipped, result.events)
+    @test length(skipped_events) == 1
+    @test isempty(filter(e -> e.event == :errored, result.events))
+end
+
+@testitem "Skip expression with a trailing comment" setup=[TestHelpers] begin
+    # The re-parenthesization puts the closing paren on its own line so a trailing line
+    # comment in the source text cannot swallow it.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = [TestHelpers.with_skip(discovered.items[1], "true # always")]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    @test length(filter(e -> e.event == :skipped, result.events)) == 1
+end
+
+@testitem "Skip expression that throws errors the item" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = [TestHelpers.with_skip(discovered.items[1], "error(\"cannot decide\")")]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    errored_events = filter(e -> e.event == :errored, result.events)
+    @test length(errored_events) == 1
+    @test occursin("skip", errored_events[1].messages[1].message)
+    @test isempty(filter(e -> e.event == :skipped, result.events))
+end
+
+@testitem "Skip expression that is not a Bool errors the item" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = [TestHelpers.with_skip(discovered.items[1], "42")]
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    errored_events = filter(e -> e.event == :errored, result.events)
+    @test length(errored_events) == 1
+    @test occursin("must evaluate to a `Bool`", errored_events[1].messages[1].message)
+end
+
+@testitem "Perf stats are reported for a passing item" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    result = TestHelpers.run_testrun(discovered)
+
+    passed_events = filter(e -> e.event == :passed, result.events)
+    @test length(passed_events) > 0
+
+    perf = passed_events[1].perf
+    @test perf !== nothing
+    @test perf.elapsed !== nothing && perf.elapsed >= 0
+    @test perf.bytes !== nothing && perf.bytes >= 0
+    @test perf.allocs !== nothing && perf.allocs >= 0
+    @test perf.gctime !== nothing && perf.gctime >= 0
+
+    # Compile timings come from `Base.cumulative_compile_timing`, which does not exist on
+    # every Julia version the test process supports. The contract is that they are `nothing`
+    # there rather than an error — so the only assertion that holds everywhere is that the
+    # item still produced a normal result, which the `passed` event above already shows.
+    if VERSION >= v"1.8"
+        @test perf.compile_time !== nothing
+        @test perf.recompile_time !== nothing
+    end
+end
+
+@testitem "Perf stats degrade instead of erroring on a Julia without compile timing" setup=[TestHelpers] begin
+    using TestItemControllers: JSON
+
+    # `Base.cumulative_compile_timing` only exists from 1.8 on, and the test process supports
+    # every version back to 1.0. The degradation contract is that the compile timings come
+    # back `nothing` and the item still runs — not that anything throws.
+    installed = try
+        config = JSON.parse(read(`juliaup api getconfig1`, String))
+        channels = Set{String}([config["DefaultChannel"]["Name"]])
+        for ch in get(config, "OtherChannels", [])
+            push!(channels, ch["Name"])
+        end
+        channels
+    catch err
+        Set{String}()
+    end
+
+    if "1.6" in installed
+        pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+        discovered = TestHelpers.discover_test_items(pkg_path)
+        items = filter(i -> i.label == "add works", discovered.items)
+
+        result = TestHelpers.run_testrun(items, discovered.setups, discovered; julia_cmd="julia", julia_args=["+1.6"], timeout=600)
+
+        passed_events = filter(e -> e.event == :passed, result.events)
+        @test length(passed_events) == 1
+
+        perf = passed_events[1].perf
+        @test perf !== nothing
+        @test perf.compile_time === nothing
+        @test perf.recompile_time === nothing
+        # The parts that do not depend on 1.8 internals are still measured.
+        @test perf.elapsed !== nothing
+        @test perf.bytes !== nothing
+    else
+        @info "Skipping the old-Julia perf degradation check: juliaup channel 1.6 is not installed."
+        @test true
+    end
+end
+
+@testitem "Perf stats are reported for failing and erroring items" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label in ("failing test", "erroring test"), discovered.items)
+    @test length(items) == 2
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    terminal = filter(e -> e.event in (:failed, :errored), result.events)
+    @test length(terminal) == 2
+    @test all(e -> e.perf !== nothing, terminal)
+    @test all(e -> e.perf.elapsed !== nothing, terminal)
+end
+
+@testitem "Setup output is replayed onto every dependent item" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "SetupOutputPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> startswith(i.label, "chatty consumer"), discovered.items)
+    @test length(items) == 3
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    passed_events = filter(e -> e.event == :passed, result.events)
+    @test length(passed_events) == 3
+
+    # All three items see the setup's output, not just whichever one triggered the single
+    # evaluation, and it is fenced with a header naming the setup (analysis A.3).
+    for item in items
+        output = get(result.outputs, item.id, "")
+        @test occursin("CHATTY_SETUP_MARKER", output)
+        @test occursin("output from @testmodule ChattySetup", output)
+    end
+end
+
+@testitem "Setup output is replayed again on a pooled process" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "SetupOutputPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> startswith(i.label, "chatty consumer"), discovered.items)
+
+    # Two runs against one controller: the second reuses the warm process, on which the
+    # setup is already evaluated and would previously have printed nothing at all.
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered; n_runs=2)
+
+    @test length(result.runs) == 2
+
+    for run in result.runs
+        @test length(filter(e -> e.event == :passed, run.events)) == 3
+        for item in items
+            output = get(run.outputs, item.id, "")
+            @test occursin("CHATTY_SETUP_MARKER", output)
+        end
+    end
+end
+
+@testitem "Replayed setup output is capped" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "SetupOutputPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label == "loud consumer", discovered.items)
+    @test length(items) == 1
+
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered)
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 1
+
+    output = get(result.outputs, items[1].id, "")
+    @test occursin("LOUD_LINE_1_", output)
+    @test occursin("bytes of setup output truncated", output)
+    # The cap is 32 KiB; the fence and the CRLF translation add a little on top of it.
+    @test ncodeunits(output) < 48 * 1024
+    @test !occursin("LOUD_LINE_2000_", output)
+end

--- a/testdata/SetupOutputPackage/Project.toml
+++ b/testdata/SetupOutputPackage/Project.toml
@@ -1,0 +1,3 @@
+name = "SetupOutputPackage"
+uuid = "a1b2c3d4-0001-0002-0003-000000000005"
+version = "0.1.0"

--- a/testdata/SetupOutputPackage/src/SetupOutputPackage.jl
+++ b/testdata/SetupOutputPackage/src/SetupOutputPackage.jl
@@ -1,0 +1,7 @@
+module SetupOutputPackage
+
+export shout
+
+shout(x) = uppercase(string(x))
+
+end # module SetupOutputPackage

--- a/testdata/SetupOutputPackage/test/runtests.jl
+++ b/testdata/SetupOutputPackage/test/runtests.jl
@@ -1,0 +1,3 @@
+using TestItemRunner
+
+@run_package_tests

--- a/testdata/SetupOutputPackage/test/setup_output_tests.jl
+++ b/testdata/SetupOutputPackage/test/setup_output_tests.jl
@@ -1,0 +1,28 @@
+@testmodule ChattySetup begin
+    println("CHATTY_SETUP_MARKER")
+    const VALUE = 7
+end
+
+@testitem "chatty consumer one" setup=[ChattySetup] begin
+    @test ChattySetup.VALUE == 7
+end
+
+@testitem "chatty consumer two" setup=[ChattySetup] begin
+    @test ChattySetup.VALUE == 7
+end
+
+@testitem "chatty consumer three" setup=[ChattySetup] begin
+    @test ChattySetup.VALUE == 7
+end
+
+@testmodule LoudSetup begin
+    # Well over the 32 KiB replay cap, so the replayed copy must be truncated.
+    for i in 1:2000
+        println("LOUD_LINE_", i, "_", repeat("x", 40))
+    end
+    const VALUE = 1
+end
+
+@testitem "loud consumer" setup=[LoudSetup] begin
+    @test LoudSetup.VALUE == 1
+end

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -20,6 +20,12 @@ mutable struct Testsetup
     column::Int
     code::String
     evaled::Bool
+    # Output and wall time captured the one time this setup was evaluated on this process.
+    # The output is replayed onto every item that declares the setup — including items from
+    # later test runs handed to this pooled process — so which item happened to trigger the
+    # evaluation stops being observable. Both are reset when the setup's code changes.
+    captured_output::String
+    duration::Union{Nothing,Float64}
 end
 
 mutable struct TestProcessState
@@ -272,6 +278,139 @@ function process_coverage_data(coverage_results)
     return coverage_info
 end
 
+# Maximum amount of a setup's captured output that is replayed onto a dependent item. A
+# chatty setup would otherwise be multiplied by the number of items that declare it.
+const MAX_REPLAYED_SETUP_OUTPUT = 32 * 1024
+
+function truncate_setup_output(s::AbstractString)
+    ncodeunits(s) <= MAX_REPLAYED_SETUP_OUTPUT && return String(s)
+    i = MAX_REPLAYED_SETUP_OUTPUT
+    while i > 0 && !Base.isvalid(s, i)
+        i -= 1
+    end
+    return string(SubString(s, 1, i), "\n… ($(ncodeunits(s) - i) bytes of setup output truncated)\n")
+end
+
+# Evaluate `f` with `stdout`/`stderr` captured into `out[]`, truncated. The redirection is
+# process-wide, which is only acceptable because it is used around setup evaluation, where
+# the runner loop is the only thing producing output. `out[]` is set even when `f` throws.
+function with_captured_output(f, out::Base.RefValue{String})
+    orig_stdout = stdout
+    orig_stderr = stderr
+
+    rd, wr = redirect_stdout()
+    redirect_stderr(wr)
+
+    reader = @async read(rd, String)
+
+    try
+        return f()
+    finally
+        redirect_stdout(orig_stdout)
+        redirect_stderr(orig_stderr)
+        close(wr)
+        out[] = try
+            truncate_setup_output(fetch(reader))
+        catch
+            ""
+        end
+        close(rd)
+    end
+end
+
+# Setup output is captured and replayed rather than shown live, so that every item declaring
+# the setup sees it and not just whichever item happened to trigger the single evaluation
+# (analysis A.3). The fence names the setup, which also explains why a sibling item shows the
+# same block.
+function replay_setup_output(name::AbstractString, kind::Symbol, text::AbstractString)
+    isempty(text) && return
+
+    macro_name = kind === :module ? "@testmodule" : "@testsnippet"
+
+    print(stderr, "\n── output from $macro_name $name (evaluated on this worker) ──\n")
+    print(stderr, text)
+    endswith(text, "\n") || print(stderr, "\n")
+    print(stderr, "── end output from $macro_name $name ──\n")
+    flush(stderr)
+
+    return nothing
+end
+
+# `Base.cumulative_compile_timing` and `Base.cumulative_compile_time_ns` are internals that
+# only exist from Julia 1.8 on, while the test process supports every version back to 1.0
+# (see `testprocess/environments/`). Everything below degrades to `missing` instead of
+# throwing, so a missing compile timing never turns into a spurious errored test item.
+const HAS_COMPILE_TIMING = isdefined(Base, :cumulative_compile_timing) && isdefined(Base, :cumulative_compile_time_ns)
+
+function start_compile_timing()
+    HAS_COMPILE_TIMING || return nothing
+    try
+        Base.cumulative_compile_timing(true)
+        before = Base.cumulative_compile_time_ns()
+        if !(before isa Tuple{Any,Any})
+            Base.cumulative_compile_timing(false)
+            return nothing
+        end
+        return before
+    catch err
+        return nothing
+    end
+end
+
+function stop_compile_timing(before)
+    before === nothing && return (missing, missing)
+    try
+        after = Base.cumulative_compile_time_ns()
+        Base.cumulative_compile_timing(false)
+        return ((after[1] - before[1]) / 1e6, (after[2] - before[2]) / 1e6)
+    catch err
+        try Base.cumulative_compile_timing(false) catch end
+        return (missing, missing)
+    end
+end
+
+function start_gc_timing()
+    try
+        return Base.gc_num()
+    catch err
+        return nothing
+    end
+end
+
+function collect_perf_stats(elapsed_ms, gc_before, compile_before)
+    compile_time, recompile_time = stop_compile_timing(compile_before)
+
+    bytes = missing
+    allocs = missing
+    gctime = missing
+
+    if gc_before !== nothing
+        try
+            diff = Base.GC_Diff(Base.gc_num(), gc_before)
+            bytes = Int(diff.allocd)
+            allocs = Int(Base.gc_alloc_count(diff))
+            gctime = diff.total_time / 1e6
+        catch err
+        end
+    end
+
+    return TestItemServerProtocol.PerfStatsParams(
+        elapsed = Float64(elapsed_ms),
+        bytes = bytes,
+        allocs = allocs,
+        gctime = gctime,
+        compile_time = compile_time,
+        recompile_time = recompile_time,
+    )
+end
+
+# JuliaSyntax treats parentheses as trivia, so the source range recorded for
+# `skip=(VERSION < v"1.11")` yields `VERSION < v"1.11"` with the parentheses gone. Splicing
+# that back bare would let it reassociate — `skip=a ? b : c` is the clearest case — so the
+# text is always re-parenthesized. The newlines mean a trailing line comment cannot swallow
+# the closing parenthesis.
+parenthesized_skip_code(skip::AbstractString) = string("(\n", skip, "\n)")
+
 # `testcode_module_parent` exists for the precompile workload: during package-image
 # generation `Main` is closed, so the throwaway module holding the test code must be
 # created inside the (still open) TestItemServer module instead.
@@ -288,6 +427,74 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
     cd(working_dir)
 
     coverage_results = CoverageTools.FileCoverage[] # This will hold the results of various coverage sprints
+
+    # `skip` is evaluated here — in the test process, before anything else is done for this
+    # item — because that is the only place that can answer `VERSION < v"1.11"` or
+    # `Sys.iswindows()` for the process the item would actually have run in. Evaluating it
+    # ahead of the setups also means a skipped item never pays for them.
+    if params.skip !== missing
+        skip_result = nothing
+        skip_error = nothing
+
+        try
+            skip_module = Core.eval(testcode_module_parent, :(module $(gensym()) end))
+            skip_result = Base.invokelatest(
+                include_string,
+                skip_module,
+                parenthesized_skip_code(params.skip),
+                uri2filepath(params.uri)
+            )
+        catch err
+            skip_error = (err, catch_backtrace())
+        end
+
+        if skip_error !== nothing
+            err, bt = skip_error
+
+            return (
+                TestItemServerProtocol.errored_notification_type,
+                TestItemServerProtocol.ErroredParams(
+                    testItemId = params.id,
+                    messages = [
+                        TestItemServerProtocol.TestMessage(
+                            message = "Error while evaluating the `skip` option: $(format_error_message(err, bt))",
+                            location = TestItemServerProtocol.Location(
+                                params.uri,
+                                TestItemServerProtocol.Position(params.line, 1)
+                            ),
+                            stackTrace = backtrace_to_stackframes(bt),
+                        )
+                    ],
+                    duration = missing
+                )
+            )
+        elseif skip_result === true
+            return (
+                TestItemServerProtocol.skipped_notification_type,
+                TestItemServerProtocol.SkippedParams(
+                    testItemId = params.id,
+                    reason = params.skip
+                )
+            )
+        elseif skip_result !== false
+            return (
+                TestItemServerProtocol.errored_notification_type,
+                TestItemServerProtocol.ErroredParams(
+                    testItemId = params.id,
+                    messages = [
+                        TestItemServerProtocol.TestMessage(
+                            "The `skip` option must evaluate to a `Bool`, but it evaluated to a value of type `$(typeof(skip_result))`.",
+                            TestItemServerProtocol.Location(
+                                params.uri,
+                                TestItemServerProtocol.Position(params.line, 1)
+                            )
+                        )
+                    ],
+                    duration = missing
+                )
+            )
+        end
+    end
 
     for i in params.testSetups
         if !haskey(state.test_setups, (params.packageUri, Symbol(i)))
@@ -318,16 +525,37 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
 
             filepath = uri2filepath(setup_details.uri)
 
+            captured_output = Ref("")
             t0 = time_ns()
             try
-                withpath(filepath) do
-                    Logging.with_logger(Logging.ConsoleLogger(stderr, state.log_level)) do
-                        Base.invokelatest(include_string, mod, code, filepath)
+                with_captured_output(captured_output) do
+                    withpath(filepath) do
+                        Logging.with_logger(Logging.ConsoleLogger(stderr, state.log_level)) do
+                            Base.invokelatest(include_string, mod, code, filepath)
+                        end
                     end
                 end
+                setup_details.duration = (time_ns() - t0) / 1e6 # Convert to milliseconds
+                setup_details.captured_output = captured_output[]
                 setup_details.evaled = true
+
+                JSONRPC.send(
+                    endpoint,
+                    TestItemServerProtocol.setup_evaluated_notification_type,
+                    TestItemServerProtocol.SetupEvaluatedParams(
+                        name = setup_details.name,
+                        packageUri = params.packageUri,
+                        durationMs = setup_details.duration,
+                        output = setup_details.captured_output,
+                    )
+                )
             catch err
                 elapsed_time = (time_ns() - t0) / 1e6 # Convert to milliseconds
+
+                # Whatever the setup printed before it failed is the most useful thing the
+                # user can be shown, so it is replayed here rather than discarded. It is
+                # deliberately not cached: the setup stays unevaluated and will be retried.
+                replay_setup_output(setup_details.name, :module, captured_output[])
 
                 bt = catch_backtrace()
                 st = stacktrace(bt)
@@ -423,6 +651,11 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
         try
             if testsetup_details.kind==:module
                 Core.eval(mod, :(using ..Testsetups.$(Symbol(i))))
+
+                # Replayed for every item that declares the setup, not just the one that
+                # triggered the single evaluation — and on a pooled process that evaluated it
+                # during an earlier run, where no item would otherwise show it at all.
+                replay_setup_output(testsetup_details.name, :module, testsetup_details.captured_output)
             elseif testsetup_details.kind==:snippet
                 testsnippet_filepath = uri2filepath(testsetup_details.uri)
                 testsnippet_code = string('\n'^(testsetup_details.line-1), ' '^(testsetup_details.column-1), testsetup_details.code)
@@ -433,13 +666,35 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
                         DebugAdapter.debug_code(debug_session, mod, testsnippet_code, testsnippet_filepath)
                     else
                         mode == "Coverage" && clear_coverage_data()
+                        # A snippet is re-evaluated into every item's scope, so its output
+                        # already reached every dependent item. It is still captured and
+                        # replayed, so that it carries the same fence as a `@testmodule`'s
+                        # and so the controller learns what it cost.
+                        captured_output = Ref("")
+                        t0 = time_ns()
                         try
-                            Logging.with_logger(Logging.ConsoleLogger(stderr, state.log_level)) do
-                                Base.invokelatest(include_string, mod, testsnippet_code, testsnippet_filepath)
+                            with_captured_output(captured_output) do
+                                Logging.with_logger(Logging.ConsoleLogger(stderr, state.log_level)) do
+                                    Base.invokelatest(include_string, mod, testsnippet_code, testsnippet_filepath)
+                                end
                             end
                         finally
+                            testsetup_details.duration = (time_ns() - t0) / 1e6 # Convert to milliseconds
+                            testsetup_details.captured_output = captured_output[]
                             mode == "Coverage" && collect_coverage_data!(coverage_results, coverage_root_uris)
+                            replay_setup_output(testsetup_details.name, :snippet, captured_output[])
                         end
+
+                        JSONRPC.send(
+                            endpoint,
+                            TestItemServerProtocol.setup_evaluated_notification_type,
+                            TestItemServerProtocol.SetupEvaluatedParams(
+                                name = testsetup_details.name,
+                                packageUri = params.packageUri,
+                                durationMs = testsetup_details.duration,
+                                output = testsetup_details.captured_output,
+                            )
+                        )
                     end
                 end
             else
@@ -477,6 +732,20 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
 
     elapsed_time = UInt64(0)
 
+    # Perf counters are armed around the item body only, so the setups evaluated above are
+    # not charged to whichever item happened to trigger them.
+    perf = missing
+    perf_collected = false
+    gc_before = start_gc_timing()
+    compile_before = start_compile_timing()
+
+    collect_perf! = () -> begin
+        perf_collected && return nothing
+        perf_collected = true
+        perf = collect_perf_stats(elapsed_time, gc_before, compile_before)
+        return nothing
+    end
+
     inner_test_function = () -> begin
         t0 = time_ns()
         try
@@ -496,11 +765,13 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
                     end
                 end
                 elapsed_time = (time_ns() - t0) / 1e6 # Convert to milliseconds
+                collect_perf!()
             end
 
             return nothing
         catch err
             elapsed_time = (time_ns() - t0) / 1e6 # Convert to milliseconds
+            collect_perf!()
 
             bt = catch_backtrace()
             st = stacktrace(bt)
@@ -524,9 +795,14 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
                             stackTrace = stack_frames,
                         )
                     ],
-                    duration = missing
+                    duration = missing,
+                    perf = perf
                 )
             )
+        finally
+            # Belt and braces: whatever path we leave by, the compile-timing counter this
+            # item enabled has to be disabled again.
+            collect_perf!()
         end
     end
 
@@ -559,7 +835,8 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
             TestItemServerProtocol.PassedParams(
                 testItemId = params.id,
                 duration = elapsed_time,
-                coverage = process_coverage_data(coverage_results)
+                coverage = process_coverage_data(coverage_results),
+                perf = perf
             )
         )
     catch err
@@ -571,7 +848,8 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
                 TestItemServerProtocol.FailedParams(
                     testItemId = params.id,
                     messages = [ create_test_message_for_failed(i) for i in failed_tests],
-                    duration = elapsed_time
+                    duration = elapsed_time,
+                    perf = perf
                 )
             )
         else
@@ -774,7 +1052,9 @@ function configure_test_run_request(params::TestItemServerProtocol.ConfigureTest
                 i.line,
                 i.column,
                 i.code,
-                false
+                false,
+                "",
+                nothing
             )
         else
             val = state.test_setups[key]
@@ -783,6 +1063,11 @@ function configure_test_run_request(params::TestItemServerProtocol.ConfigureTest
                 val.evaled = false
                 val.code = i.code
                 val.kind = Symbol(i.kind)
+                # The cached output describes the *previous* code, so it must not be
+                # replayed onto items in this run — the setup will be re-evaluated and
+                # captured again.
+                val.captured_output = ""
+                val.duration = nothing
             end
 
             val.uri = i.uri


### PR DESCRIPTION
Stream **S3 — Worker execution** of the ReTestItems delta plan. Based on
`s2-tic-foundation` (#38), not `main` — S2 landed the protocol fields and shared
plumbing this builds on.

Implements analysis items **A.10 #5 (`skip` as an item kwarg)**, **#9 (setup output
attribution, A.3)** and **#12 (per-item perf stats)**. All three live in
`run_testitem`, which is why the plan grouped them.

## `skip`

Evaluated in a throwaway module in the **test process**, before anything else is done
for the item. Test-process-side because that is the only place that can answer
`VERSION < v"1.11"` or `Sys.iswindows()` for the process the item would have run in
(A.1 refinement 1); ahead of the setups so a skipped item never pays for them.

A `true` result sends the new `skipped` notification carrying the source text as its
reason. The controller handles it as a terminal result in the existing pattern —
cancel the timeout, ownership check, drop the work unit, `_notify_testitem_skipped`.
An expression that throws, or that evaluates to a non-`Bool`, errors the item with a
specific message rather than being silently treated as `false`.

**The parenthesization gotcha found by S1 is handled and tested.** JuliaSyntax records
parentheses as trivia, so `skip=(VERSION < v"1.11")` reaches the wire as
`VERSION < v"1.11"` with the parentheses gone; spliced in bare, an expression like
`skip=a ? b : c` reassociates. The source text is therefore always wrapped as
`"(\n" * text * "\n)"` — the newlines also mean a trailing line comment cannot swallow
the closing paren. Both cases have a test item.

## Perf stats

Armed around the item body only, so the setups evaluated above it are not charged to
whichever item triggered them. `elapsed`/`bytes`/`allocs`/`gctime` come from
`Base.gc_num`/`Base.GC_Diff`; `compile_time`/`recompile_time` from
`Base.cumulative_compile_timing`, which is internal and only exists from 1.8 while the
test process supports every version back to 1.0 (`testprocess/environments/`).

Everything degrades to `missing` instead of throwing — an internals change must never
turn into a spurious errored test item. The degradation path is covered by a test item
that runs against juliaup channel 1.6 when installed (and reports that it skipped when
not), asserting the compile timings come back `nothing` while the rest is still
measured.

## Setup output attribution (A.3)

Each setup's output and wall time are captured at evaluation, and the output is
replayed — fenced with `── output from @testmodule Foo (evaluated on this worker) ──` —
onto **every** item that declares the setup. Previously exactly one item showed it,
nondeterministically (it depended on stealing order), and *no* item showed it when the
process was pooled from an earlier run that had already evaluated the setup.

- Survives pooling: the replay is driven by the worker's own setup cache, so a second
  run against the warm process replays it again. Tested with two runs on one controller.
- Invalidated when the setup's code changes: `configure_test_run_request` already
  resets `evaled`, and now clears the cached output and duration with it, so the next
  evaluation recaptures. An env-hash change restarts the process, which clears it too.
- Capped at 32 KiB with a truncation notice, so a chatty setup is not multiplied by N
  items. Tested with a setup that prints ~100 KiB.

`@testsnippet`s are captured too — they already reached every dependent item, since
they are re-evaluated per item, but they now carry the same fence and report their cost.

The new `setup_evaluated` notification lands in `TestProcessState.loaded_setups` on the
controller, which is what **S5** reads for its scheduling cost model.

## ⚠️ Required VS Code extension changes

S2 deliberately left `src/json_protocol.jl` alone and noted the update "comes due in
S3". It is due — `skipped` and `perf` now actually flow. The extension must be updated
in lockstep with this PR:

1. **`TestItemDetail` gains `optionSkip: boolean | string | undefined`** (in
   `createTestRun`). The extension must send the `skip` kwarg it gets from discovery:
   `true`/`false` for a literal, the expression's source text otherwise. Omitting the
   field is treated as `false`, so an un-updated extension keeps working — it just
   never skips anything.
2. **`testItemSkipped` changes shape from `{testRunId, testItemId}` to a struct with an
   optional `reason: string`.** Additive on the wire (existing fields unchanged), but
   the extension should surface the reason — it is the `skip` source text, and is the
   only explanation the user gets for why an item did not run.
3. **`testItemPassed`/`testItemFailed`/`testItemErrored` gain optional
   `perf: { elapsed?, bytes?, allocs?, gctime?, compileTime?, recompileTime? }`**
   (milliseconds / bytes / counts). Optional, so ignoring it is safe; rendering it is
   the point of the feature.

Nothing else in `json_protocol.jl` changed and no existing field was removed or
renamed, so an extension that ignores all three keeps working with only `skip`
non-functional.

## Notes for the other wave-2 streams

- `src/messages.jl` is not in the file-ownership table. I added a trailing `perf` field
  to `TestItemPassedMsg`/`FailedMsg`/`ErroredMsg` (with defaulting constructors, so
  every existing call site compiles unchanged) and two new message types,
  `TestItemSkippedMsg` and `TestSetupEvaluatedMsg`. Nothing S4 or S5 owns was touched.
- The worker's own `Testsetup` struct in `TestItemServer.jl` gained
  `captured_output`/`duration`. That is the worker's private cache, not one of the
  shared controller structs the plan warned about.
- `ps.loaded_setups` is populated but never pruned when the controller sends a *changed*
  setup to a pooled process — the worker invalidates its own cache correctly, but the
  controller's copy of the duration goes stale until the setup is re-evaluated. Pruning
  it belongs in the pool code, which S4 owns. Harmless today (only S5's cost model reads
  it, and a stale duration only mis-ranks); flagging it rather than reaching into S4's
  region.
- `test/test_helpers.jl` gained `with_skip` and an `n_runs` argument to `run_testrun`
  (multiple runs against one controller, for the pooled-worker case) plus output
  capture. Existing callers are unaffected — `result.events` still means what it did.

## Testing

`julia_run_testitems` over the worktree (not `Pkg.test`): **147/147 green**, i.e. the
134 pre-existing items plus 13 new ones in `test/test_worker_execution.jl`. One earlier
full run showed `createTestRun request with passing items` failing on a
`registries\$....pid.deleted` EACCES raised by a concurrent Pkg registry access from a
parallel stream's worktree; it passes in isolation and in the clean full run.

New testdata package `testdata/SetupOutputPackage` provides a `@testmodule` shared by
three items and a deliberately loud one for the cap test.

## What in the plan proved wrong

Nothing substantive. Two small deviations, both noted inline:

- The plan places the `skip` check "before the item's module is created (:352)", i.e.
  after the setup loop. It is instead placed before the setup loop, so a skipped item
  does not pay for evaluating its setups. It is still before the module is created.
- The plan has the setup output replayed by the controller from `loaded_setups`. The
  worker replays it instead, which is strictly simpler: the existing sentinel framing
  attributes it to the running item for free, and it works identically for items from a
  later run on a pooled process. `loaded_setups` is still populated controller-side —
  S5 needs the cost, not the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
