### PR TITLE
Worker lifecycle: hang diagnostics, GC between test items, memory recycling

### DIFF
--- a/src/state.jl
+++ b/src/state.jl
@@ -103,6 +103,11 @@ mutable struct TestRunState
     cancellation_source::CancellationTokens.CancellationTokenSource
     completion_channel::Channel{Any}    # reactor puts result here; execute_testrun waits on it
     reported_items::Set{String}         # testitem_ids for which a terminal callback was emitted
+    # Worker lifecycle policy for this run, sent on to each process in ConfigureTestRun.
+    # `gc_between_testitems` is resolved from the caller's request in `execute_testrun`
+    # (default: on whenever the run uses more than one process).
+    gc_between_testitems::Bool
+    memory_threshold::Union{Nothing,Float64}
 end
 
 function TestRunState(
@@ -114,6 +119,8 @@ function TestRunState(
     max_processes::Int;
     coverage_root_uris::Union{Nothing,Vector{String}}=nothing,
     token::Union{Nothing,CancellationTokens.CancellationToken}=nothing,
+    gc_between_testitems::Bool=false,
+    memory_threshold::Union{Nothing,Float64}=nothing,
 )
     cancellation_source = token === nothing ?
         CancellationTokens.CancellationTokenSource() :
@@ -140,6 +147,8 @@ function TestRunState(
         cancellation_source,
         Channel{Any}(1),                            # completion_channel
         Set{String}(),                              # reported_items
+        gc_between_testitems,
+        memory_threshold,
     )
 end
 

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -1244,9 +1244,10 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
             end
             _check_testrun_complete!(c, tr)
             return
-        else
+        elseif !recycled
             # Process was functional and was killed after running items (e.g., timeout).
-            # Fall through to redistribute remaining un-started items.
+            # Fall through to redistribute remaining un-started items. A memory recycle
+            # takes the same path but has already said so above, in accurate terms.
             @info "Test process '$(terminated_proc_id)' terminated after running items, redistributing $(length(items_to_redistribute)) remaining item(s)"
         end
     end
@@ -1257,7 +1258,10 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
         return
     end
 
-    @info "Redistributing $(length(items_to_redistribute)) un-started item(s) from crashed process '$(terminated_proc_id)'"
+    # Never call a memory recycle a crash: this is the diagnostic path the feature exists to
+    # keep readable, and a deliberate exit reported as a crash sends anyone reading a CI log
+    # looking for a fault that isn't there.
+    @info "Redistributing $(length(items_to_redistribute)) un-started item(s) from $(recycled ? "recycled" : "crashed") process '$(terminated_proc_id)'"
 
     # Try to find another live process in the same env
     recipient_pid = nothing

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -398,40 +398,11 @@ function handle!(c::TestItemController, msg::GetProcsForTestRunMsg)
             @debug "Checking whether test environment precompilation is needed"
             coverage_arg = k.mode == "Coverage" ? "--code-coverage=user" : "--code-coverage=none"
 
-            jlEnv = copy(ENV)
+            jlEnv = _subprocess_env(k)
 
-            # During precompilation, Julia restricts JULIA_LOAD_PATH to dependency paths only
-            # (no "@" entry), which prevents child processes from using their own active project.
-            if ccall(:jl_generating_output, Cint, ()) == 1
-                delete!(jlEnv, "JULIA_LOAD_PATH")
-            end
+            julia_version = _resolve_julia_version(c, k)
 
-            for (ek, ev) in pairs(k.env)
-                if ev !== nothing
-                    jlEnv[ek] = ev
-                elseif haskey(jlEnv, ek)
-                    delete!(jlEnv, ek)
-                end
-            end
-
-            # The subprocess exists only to detect Julia <= 1.10 for the
-            # precompile hack below. When the test processes use exactly the
-            # binary this process is running, the answer is already known —
-            # skip the ~0.3-0.5s `julia --version` launch. (A bare "julia"
-            # must still be probed: PATH or a juliaup channel can resolve it
-            # to a different version than the running process.)
-            julia_version = if isempty(k.juliaArgs) &&
-                    k.juliaCmd == joinpath(Sys.BINDIR, Base.julia_exename())
-                VERSION
-            else
-                get!(c.julia_version_cache, (k.juliaCmd, k.juliaArgs)) do
-                    julia_version_as_string = read(Cmd(`$(k.juliaCmd) $(k.juliaArgs) --version`, detach=false, env=jlEnv), String)
-                    julia_version_as_string = julia_version_as_string[length("julia version")+2:end]
-                    VersionNumber(julia_version_as_string)
-                end
-            end
-
-            if julia_version <= v"1.10.0"
+            if julia_version !== nothing && julia_version <= v"1.10.0"
                 testserver_precompile_script = joinpath(@__DIR__, "../testprocess/app/testserver_precompile.jl")
 
                 # "auto" is Julia's default and rejected as a flag value before 1.8 — only
@@ -699,7 +670,10 @@ function handle!(c::TestItemController, msg::TestItemStartedMsg)
         timeout = wu !== nothing ? wu.timeout : nothing
 
         if timeout !== nothing
-            ps.timeout_cs = CancellationTokens.CancellationTokenSource(timeout)
+            # The test process's watchdog fires at the item's real deadline; we wait a grace
+            # period beyond it so its diagnostic dump is on disk before we kill the process.
+            # The item is still reported as having timed out after `timeout` seconds.
+            ps.timeout_cs = CancellationTokens.CancellationTokenSource(timeout + WATCHDOG_KILL_GRACE_SECONDS)
             ps.timeout_reg = CancellationTokens.register(CancellationTokens.get_token(ps.timeout_cs)) do
                 try
                     put!(c.reactor_channel, TestItemTimeoutMsg(msg.testrun_id, msg.testprocess_id, msg.testitem_id))
@@ -1161,6 +1135,16 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
     ps = haskey(c.test_processes, terminated_proc_id) ? c.test_processes[terminated_proc_id] : nothing
     crashed_item_id = ps !== nothing ? ps.current_testitem_id : nothing
 
+    # A memory recycle is a clean, deliberate exit taken *between* items, after the last
+    # result was reported — so there is no in-flight item to blame, and the remaining items
+    # go through the ordinary redistribute-or-respawn path below rather than being errored.
+    recycled = ps !== nothing && ps.last_exit_code == MEMORY_RECYCLE_EXIT_CODE
+    if recycled
+        @info "Test process '$(terminated_proc_id)' stopped itself to release memory, redistributing $(length(items_to_redistribute)) remaining item(s)"
+        _cancel_timeout!(ps)
+        crashed_item_id = nothing
+    end
+
     crashed_work_key = crashed_item_id !== nothing ? (crashed_item_id, test_env_id) : nothing
     if crashed_item_id !== nothing && haskey(tr.remaining_work, crashed_work_key)
         # A test item was actively running when the process crashed — error it immediately.
@@ -1386,6 +1370,15 @@ function handle!(c::TestItemController, msg::TestItemTimeoutMsg)
     timeout_val = wu !== nothing && wu.timeout !== nothing ? wu.timeout : "?"
 
     @warn "Test item '$(item_label)' timed out after $(timeout_val) seconds"
+
+    # Attach whatever the test process's watchdog managed to dump before we report the item
+    # as errored, so the backtrace shows up as that item's output. The dump is absent when
+    # the item wedged without ever reaching a GC safepoint, or when the process has no spare
+    # thread to run the watchdog on — both degrade to today's behaviour.
+    diagnostics = _read_diagnostics(msg.testprocess_id)
+    if diagnostics !== nothing
+        c.callbacks.on_append_output(msg.testrun_id, msg.testitem_id, test_env_id, replace(diagnostics, "\n"=>"\r\n"))
+    end
 
     _cancel_timeout!(ps)
 
@@ -1749,6 +1742,56 @@ end
 # Process management helpers
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Build the environment a subprocess for `penv` runs in, applying the test environment's
+# overlay (a `nothing` value deletes the variable) on top of ours.
+function _subprocess_env(penv::ProcessEnv)
+    jlEnv = copy(ENV)
+
+    # During precompilation, Julia restricts JULIA_LOAD_PATH to dependency paths only
+    # (no "@" entry), which prevents child processes from using their own active project.
+    if ccall(:jl_generating_output, Cint, ()) == 1
+        delete!(jlEnv, "JULIA_LOAD_PATH")
+    end
+
+    for (ek, ev) in pairs(penv.env)
+        if ev !== nothing
+            jlEnv[ek] = ev
+        elseif haskey(jlEnv, ek)
+            delete!(jlEnv, ek)
+        end
+    end
+
+    return jlEnv
+end
+
+# The Julia version a test process for `penv` will run. Two callers need it: the pre-1.10
+# precompile hack, and the launch, which may only pass `--threads=N,M` to Julia >= 1.9.
+#
+# Probing costs a process launch, so the answer is cached per (cmd, args) and the common
+# case — the exact binary this controller runs, with no extra args — short-circuits. (A bare
+# "julia" must still be probed: PATH or a juliaup channel can resolve it to a different
+# version than the running process.) Returns `nothing` when the probe fails, which every
+# caller treats as "assume nothing".
+function _resolve_julia_version(c::TestItemController, penv::ProcessEnv)
+    if isempty(penv.juliaArgs) && penv.juliaCmd == joinpath(Sys.BINDIR, Base.julia_exename())
+        return VERSION
+    end
+
+    key = (penv.juliaCmd, penv.juliaArgs)
+    haskey(c.julia_version_cache, key) && return c.julia_version_cache[key]
+
+    version = try
+        version_as_string = read(Cmd(`$(penv.juliaCmd) $(penv.juliaArgs) --version`, detach=false, env=_subprocess_env(penv)), String)
+        VersionNumber(version_as_string[length("julia version")+2:end])
+    catch err
+        @warn "Could not determine the Julia version of '$(penv.juliaCmd)'" exception=(err, catch_backtrace())
+        nothing
+    end
+
+    version !== nothing && (c.julia_version_cache[key] = version)
+    return version
+end
+
 # Map common POSIX signal numbers to human-readable names.
 const _SIGNAL_NAMES = Dict{Int,String}(
     1  => "SIGHUP",
@@ -1934,10 +1977,14 @@ function _launch_julia_process!(c::TestItemController, ps::TestProcessState)
     @debug "Launching Julia process for test process" testprocess_id=ps.id package=ps.env.package_name mode=ps.env.mode is_precompile=ps.is_precompile_process precompile_done=ps.precompile_done testrun_id=something(ps.testrun_id, "none")
     put!(c.reactor_channel, TestProcessStatusChangedMsg(ps.id, "Launching"))
 
+    # Resolved here rather than in `start` so the (possibly probing) lookup stays on the
+    # reactor, where it is serialized and cached, instead of racing across IO tasks.
+    julia_version = _resolve_julia_version(c, ps.env)
+
     t = @async try
         start(ps.id, c.reactor_channel, ps, ps.env, ps.debug_pipe_name,
               c.error_handler_file, c.crash_reporting_pipename,
-              launch_token)
+              julia_version, launch_token)
     catch err
         @error "Error in test process IO" testprocess_id=ps.id exception=(err, catch_backtrace())
     end
@@ -1992,6 +2039,12 @@ function _configure_testrun!(c::TestItemController, ps::TestProcessState)
         try put!(c.reactor_channel, TestProcessIOErrorMsg(ps.id, :fatal)) catch end
         return
     end
+    # Read off the reactor, before the async send: `ps.testrun_id` may be cleared by the
+    # time the task runs.
+    tr = ps.testrun_id !== nothing ? get(c.test_runs, ps.testrun_id, nothing) : nothing
+    gc_between_testitems = tr !== nothing ? tr.gc_between_testitems : false
+    memory_threshold = tr !== nothing ? tr.memory_threshold : nothing
+
     @async try
         if ps.endpoint === nothing || !isopen(ps.endpoint)
             @debug "Configuration cancelled: endpoint gone before send" testprocess_id=ps.id
@@ -2004,7 +2057,9 @@ function _configure_testrun!(c::TestItemController, ps::TestProcessState)
                 mode = ps.env.mode,
                 logLevel = string(ps.proc_log_level),
                 coverageRootUris = something(ps.coverage_root_uris, missing),
-                testSetups = ps.test_setups
+                testSetups = ps.test_setups,
+                gcBetweenTestitems = gc_between_testitems,
+                memoryThreshold = something(memory_threshold, missing)
             )
         )
         put!(c.reactor_channel, TestProcessTestSetupsLoadedMsg(ps.id))
@@ -2031,6 +2086,19 @@ function _send_run_testitems!(c::TestItemController, ps::TestProcessState, items
         return
     end
     put!(c.reactor_channel, TestProcessStatusChangedMsg(ps.id, "Running"))
+
+    # Resolved on the reactor, where the run state is safe to read. The test process arms
+    # its hang watchdog from this; the controller's own timeout stays the backstop.
+    tr = ps.testrun_id !== nothing ? get(c.test_runs, ps.testrun_id, nothing) : nothing
+    test_env_id = tr !== nothing ? _resolve_test_env_id(tr, ps.env) : nothing
+    timeouts_ms = Dict{String,Union{Missing,Float64}}()
+    if tr !== nothing
+        for i in items
+            wu = get(tr.remaining_work, (i.id, test_env_id), nothing)
+            timeouts_ms[i.id] = wu !== nothing && wu.timeout !== nothing ? wu.timeout * 1000 : missing
+        end
+    end
+
     @async try
         if ps.endpoint === nothing || !isopen(ps.endpoint)
             @debug "Run cancelled: endpoint gone before send" testprocess_id=ps.id
@@ -2055,6 +2123,7 @@ function _send_run_testitems!(c::TestItemController, ps::TestProcessState, items
                         column = i.code_column,
                         code = i.code,
                         skip = _skip_source(i.option_skip),
+                        timeoutMs = get(timeouts_ms, i.id, missing),
                     ) for i in items
                 ],
             )
@@ -2379,7 +2448,9 @@ function execute_testrun(
     test_setups::Vector{TestSetupDetail},
     max_processes::Int,
     token;
-    coverage_root_uris::Union{Nothing,Vector{String}}=nothing)
+    coverage_root_uris::Union{Nothing,Vector{String}}=nothing,
+    gc_between_testitems::Union{Nothing,Bool}=nothing,
+    memory_threshold::Union{Nothing,Float64}=nothing)
 
     @info "Creating new test run '$(testrun_id)' with $(length(test_items)) test item(s) and $(length(test_environments)) environment(s)"
 
@@ -2395,7 +2466,8 @@ function execute_testrun(
         ],
         max_processes;
         coverage_root_uris = coverage_root_uris,
-        token = token
+        token = token,
+        memory_threshold = memory_threshold
     )
 
     # Register cancellation bridge
@@ -2435,6 +2507,13 @@ function execute_testrun(
         n_procs = max(1, min(floor(Int, max_processes * as_share), length(test_items)))
         proc_count_by_env[k] = n_procs
     end
+
+    # Collecting between items only pays for itself when memory is contended, which in
+    # practice means more than one test process — so that is the default, matching
+    # ReTestItems' `gc_between_testitems`.
+    tr.gc_between_testitems = gc_between_testitems === nothing ?
+        sum(values(proc_count_by_env), init=0) > 1 :
+        gc_between_testitems
 
     # Resolve log_level from the first work unit
     log_level = !isempty(work_units) ? first(work_units).log_level : :Info

--- a/src/testprocess.jl
+++ b/src/testprocess.jl
@@ -73,6 +73,60 @@ function _truncate_for_log(s::AbstractString; max_bytes::Int=8192)
     return SubString(s, 1, i) * "... ($(ncodeunits(s) - i) bytes truncated)"
 end
 
+# Number of interactive threads reserved in a test process. The main task — and therefore
+# the runner loop and every test item — occupies the first; the hang watchdog gets the
+# second, which is what lets it run while an item has the main thread wedged. Only the
+# *default* pool is sized from the user's `juliaNumThreads`, so `Threads.nthreads()` inside
+# a test item is unchanged by this. Requires Julia >= 1.9, which is where `--threads=N,M`
+# and the interactive threadpool arrived.
+const WATCHDOG_INTERACTIVE_THREADS = 2
+
+# How the diagnostics file reaches the test process, and the exit code it uses to say it is
+# stopping for memory recycling rather than crashing. Both are duplicated in the test
+# server (`testprocess/TestItemServer/src/watchdog.jl` and `TestItemServer.jl`); they are
+# not in `shared/testserver_protocol.jl` because they are not part of the JSONRPC schema.
+const DIAGNOSTICS_FILE_ENV_VAR = "JULIA_TESTITEMSERVER_DIAGNOSTICS_FILE"
+const MEMORY_RECYCLE_EXIT_CODE = 66
+
+# Where a test process writes its hang diagnostics. Derived from the process id rather than
+# tracked on the process state, so the controller can find it again from the timeout handler.
+_diagnostics_file_path(testprocess_id::AbstractString) =
+    joinpath(tempdir(), "testitemserver-diagnostics-$(testprocess_id).log")
+
+# How long the controller waits past an item's timeout before killing its test process, so
+# the process's watchdog has time to write a dump first.
+const WATCHDOG_KILL_GRACE_SECONDS = 5.0
+
+# Whatever the test process's watchdog has written so far, or `nothing` when it wrote
+# nothing. Consuming the file keeps a second timeout on the same process from replaying an
+# earlier item's dump.
+function _read_diagnostics(testprocess_id::AbstractString)
+    file = _diagnostics_file_path(testprocess_id)
+    return try
+        isfile(file) || return nothing
+        content = read(file, String)
+        try rm(file, force=true) catch end
+        isempty(content) ? nothing : content
+    catch err
+        @debug "Could not read hang diagnostics" testprocess_id exception=(err, catch_backtrace())
+        nothing
+    end
+end
+
+# Build the `--threads` value for a test process, folding in the interactive threads the
+# watchdog needs. `juliaNumThreads` may already carry an `N,M` pair, in which case we only
+# raise `M` far enough to leave the watchdog a thread of its own.
+function _thread_spec(juliaNumThreads::Union{Nothing,String})
+    spec = juliaNumThreads === nothing || juliaNumThreads == "" ? "1" : juliaNumThreads
+    parts = split(spec, ',')
+    if length(parts) == 1
+        return "$(parts[1]),$WATCHDOG_INTERACTIVE_THREADS"
+    end
+    interactive = tryparse(Int, parts[2])
+    interactive === nothing && return spec # e.g. "auto,auto" — leave the user's spec alone
+    return "$(parts[1]),$(max(interactive, WATCHDOG_INTERACTIVE_THREADS))"
+end
+
 struct TestProcessCrashException <: Exception
     testprocess_id::String
     exitcode::Union{Int,Nothing}
@@ -80,8 +134,9 @@ struct TestProcessCrashException <: Exception
     captured_output::String
 end
 
-function start(testprocess_id, reactor_channel, ps::TestProcessState, env::ProcessEnv, debug_pipe_name, error_handler_file, crash_reporting_pipename, token)
+function start(testprocess_id, reactor_channel, ps::TestProcessState, env::ProcessEnv, debug_pipe_name, error_handler_file, crash_reporting_pipename, julia_version, token)
     pipe_name = JSONRPC.generate_pipe_name()
+    diagnostics_file = _diagnostics_file_path(testprocess_id)
     server = Sockets.listen(pipe_name)
     try
 
@@ -101,7 +156,14 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
                 push!(jlArgs, "--check-bounds=$(env.check_bounds)")
             end
 
-            if env.juliaNumThreads!==nothing && env.juliaNumThreads == "auto"
+            # Reserve the watchdog's interactive thread where the Julia version supports it,
+            # otherwise keep the pre-existing behaviour exactly (the watchdog then degrades
+            # to "no diagnostic dump", which `start_watchdog!` handles).
+            watchdog_threads_supported = julia_version !== nothing && julia_version >= v"1.9"
+
+            if watchdog_threads_supported
+                push!(jlArgs, "--threads=$(_thread_spec(env.juliaNumThreads))")
+            elseif env.juliaNumThreads!==nothing && env.juliaNumThreads == "auto"
                 push!(jlArgs, "--threads=auto")
             end
 
@@ -121,9 +183,15 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
                 end
             end
 
-            if env.juliaNumThreads!==nothing && env.juliaNumThreads!="auto" && env.juliaNumThreads!=""
+            # Redundant once `--threads` is on the command line, and it would only confuse
+            # the picture if the two disagreed.
+            if !watchdog_threads_supported && env.juliaNumThreads!==nothing && env.juliaNumThreads!="auto" && env.juliaNumThreads!=""
                 jlEnv["JULIA_NUM_THREADS"] = env.juliaNumThreads
             end
+
+            # Set after the user's env overlay so a test environment cannot accidentally
+            # redirect the diagnostics file.
+            jlEnv[DIAGNOSTICS_FILE_ENV_VAR] = diagnostics_file
 
             error_handler_file = error_handler_file === nothing ? [] : [error_handler_file]
             crash_reporting_pipename = crash_reporting_pipename === nothing ? [] : [crash_reporting_pipename]
@@ -358,6 +426,9 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
         end
     finally
         close(server)
+        # The controller reads this while the process is still alive (from the timeout
+        # handler); once it is gone the file has no further use.
+        try rm(diagnostics_file, force=true) catch end
     end
-    
+
 end

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -159,7 +159,7 @@
     # the second run gets the pooled, already-warm test process of the first. `runs` in the
     # returned value holds the per-run events and output; `events`/`outputs` are the union
     # across runs, which is what a single-run caller wants.
-    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=300, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1)
+    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=300, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing)
         events = NamedTuple[]
         events_lock = ReentrantLock()
         push_event!(e) = lock(events_lock) do
@@ -226,7 +226,9 @@
                     setups,
                     max_procs,
                     nothing;  # token
-                    coverage_root_uris=coverage_root_uris
+                    coverage_root_uris=coverage_root_uris,
+                    gc_between_testitems=gc_between_testitems,
+                    memory_threshold=memory_threshold
                 )
             catch err
                 @error "Test run error" exception=(err, catch_backtrace())

--- a/test/test_worker_lifecycle.jl
+++ b/test/test_worker_lifecycle.jl
@@ -103,3 +103,29 @@ end
     created = filter(e -> e.event == :process_created, result.process_events)
     @test length(created) > 1
 end
+
+@testitem "A recycling test process exits without stranding the controller" setup=[TestHelpers] begin
+    # Regression test. `exit` tears the runtime down from the calling thread, so exiting
+    # while the watchdog was still running Julia code raced it: on Windows that surfaced as
+    # an `EXCEPTION_ACCESS_VIOLATION` inside the JIT, and otherwise as a process that never
+    # exited — which stranded the controller in shutdown, waiting for a termination message
+    # that could not arrive. The run itself completed, so only the shutdown hung, which is
+    # why the three-item test above did not catch it.
+    #
+    # Two items on one process is the shape that reproduced: exactly one recycle, then a
+    # replacement that finishes the run and is shut down normally. The assertion that
+    # matters is simply that this returns at all.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label in ("add works", "greet works"), discovered.items)
+    @test length(items) == 2
+
+    result = TestHelpers.run_testrun(
+        items, discovered.setups, discovered;
+        memory_threshold=0.0, max_procs=1, timeout=180,
+    )
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 2
+    @test isempty(filter(e -> e.event in (:failed, :errored), result.events))
+end

--- a/test/test_worker_lifecycle.jl
+++ b/test/test_worker_lifecycle.jl
@@ -1,0 +1,105 @@
+@testitem "GC between test items does not deadlock the test process" setup=[TestHelpers] begin
+    # Regression test for a deadlock that shipped with the watchdog and sat on the common
+    # path: `gc_between_testitems` defaults on for multi-process runs.
+    #
+    # The watchdog thread runs a loop that neither allocates nor yields, paced by
+    # `Libc.systemsleep` (a plain `ccall`). Without an explicit `GC.safepoint()` the thread
+    # never becomes collectable, so `GC.gc(true)` — which stops the world and waits for
+    # every thread — blocks forever on the first inter-item collection. The process then
+    # stops consuming items and the run wedges with no diagnostic at all.
+    #
+    # Several passing items matter: the deadlock strikes on the *second*, after the first
+    # has triggered a collection. The run timeout turns a regression into a failure rather
+    # than a hang.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label in ("add works", "greet works", "output test"), discovered.items)
+    @test length(items) == 3
+
+    result = TestHelpers.run_testrun(
+        items, discovered.setups, discovered;
+        gc_between_testitems=true, timeout=180,
+    )
+
+    passed = filter(e -> e.event == :passed, result.events)
+    @test length(passed) == 3
+    @test isempty(filter(e -> e.event in (:failed, :errored), result.events))
+end
+
+@testitem "GC between test items stays off unless requested" setup=[TestHelpers] begin
+    # The flag has to actually reach the test process for the test above to mean anything,
+    # so pin both directions rather than only the enabled one.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label == "add works", discovered.items)
+
+    result = TestHelpers.run_testrun(
+        items, discovered.setups, discovered;
+        gc_between_testitems=false, timeout=120,
+    )
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 1
+end
+
+@testitem "A timed-out test item leaves hang diagnostics in its output" setup=[TestHelpers] begin
+    # The point of the watchdog: an item killed for running too long should leave a stack
+    # behind rather than a bare "timed out" line. The dump is written to a private file by a
+    # dedicated thread and folded into the item's output by the controller, so asserting on
+    # the captured output exercises that whole path.
+    #
+    # `slow test` sleeps, which still yields — the case the watchdog can serve. An item that
+    # neither allocates nor yields never reaches a safepoint and is explicitly out of scope;
+    # the controller's own timeout remains the backstop there.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    slow = only(filter(i -> i.label == "slow test", discovered.items))
+
+    result = TestHelpers.run_testrun(
+        [slow], discovered.setups, discovered;
+        timeout=180, item_timeouts=Dict(slow.id => 5.0),
+    )
+
+    errored = filter(e -> e.testitem_id == slow.id && e.event == :errored, result.events)
+    @test length(errored) == 1
+
+    output = get(result.outputs, slow.id, "")
+    @test occursin("Hang diagnostics", output)
+    # The header carries the item and the process context, which is what makes the dump
+    # actionable when it turns up in a CI log.
+    @test occursin(slow.label, output)
+    @test occursin("Julia ", output)
+end
+
+@testitem "A test process over the memory threshold is recycled without losing items" setup=[TestHelpers] begin
+    # The worker checks system memory after each item and, when over threshold, exits
+    # cleanly with a distinguished code instead of being killed. The controller has to treat
+    # that as a recycle — redistributing un-started items through the existing termination
+    # path — rather than as a crash.
+    #
+    # A threshold of 0.0 means "always over", so every item recycles its process. That is
+    # the harshest form of the path, and it pins the invariant that matters: every item
+    # still reports exactly once, and nothing is reported as an error.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label in ("add works", "greet works", "output test"), discovered.items)
+
+    result = TestHelpers.run_testrun(
+        items, discovered.setups, discovered;
+        memory_threshold=0.0, timeout=300,
+    )
+
+    passed = filter(e -> e.event == :passed, result.events)
+    @test Set(e.testitem_id for e in passed) == Set(i.id for i in items)
+    @test length(passed) == length(items)
+    @test isempty(filter(e -> e.event in (:failed, :errored), result.events))
+
+    # Without this the test is vacuous: three items pass whether or not a single recycle
+    # happened. Each item recycles its process, so the run needs more processes than the
+    # one it started with.
+    created = filter(e -> e.event == :process_created, result.process_events)
+    @test length(created) > 1
+end

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -11,6 +11,12 @@ import Logging
 include("../../../shared/testserver_protocol.jl")
 include("helper.jl")
 include("scratch_env.jl")
+include("watchdog.jl")
+
+# Exit code the test process uses when it stops itself between test items because system
+# memory crossed `memoryThreshold`. The controller recognises it and redistributes the
+# process's un-started items instead of reporting a crash — see `_handle_termination_during_run!`.
+const MEMORY_RECYCLE_EXIT_CODE = 66
 
 mutable struct Testsetup
     name::String
@@ -36,6 +42,13 @@ mutable struct TestProcessState
     coverage_root_uris::Union{Nothing,Vector{String}}
     log_level::Base.CoreLogging.LogLevel
 
+    # Run a full `GC.gc()` after every test item. Defaulted by the controller, which turns
+    # it on whenever a run has more than one test process.
+    gc_between_testitems::Bool
+    # Fraction of system memory (0..1) above which we stop after the current item so the
+    # controller can recycle us. `nothing` disables the check.
+    memory_threshold::Union{Nothing,Float64}
+
     testitems_channel::Channel{Vector{TestItemServerProtocol.RunTestItem}}
     stolen_testitem_ids_channel::Channel{Vector{String}}
     wakeup_channel::Channel{Nothing}
@@ -47,6 +60,8 @@ mutable struct TestProcessState
             "",
             nothing,
             Logging.Info,
+            false,
+            nothing,
             Channel{Vector{TestItemServerProtocol.RunTestItem}}(Inf),
             Channel{Vector{String}}(Inf),
             Channel{Nothing}(Inf)
@@ -1036,6 +1051,8 @@ function configure_test_run_request(params::TestItemServerProtocol.ConfigureTest
     state.mode = params.mode
     state.log_level = parse_log_level(Symbol(params.logLevel))
     state.coverage_root_uris = coalesce(params.coverageRootUris, nothing)
+    state.gc_between_testitems = coalesce(params.gcBetweenTestitems, false)
+    state.memory_threshold = coalesce(params.memoryThreshold, nothing)
 
     setups_to_remove = setdiff(keys(state.test_setups), map(i->(i.packageUri,Symbol(i.name)), params.testSetups))
     for i in setups_to_remove
@@ -1098,6 +1115,20 @@ JSONRPC.@message_dispatcher dispatch_msg begin
     TestItemServerProtocol.testserver_shutdown_request_type => shutdown_request
 end
 
+# Fraction of system memory currently in use, or `nothing` when the OS numbers are not
+# available. Deliberately a whole-system figure rather than this process's RSS: what makes
+# recycling worth doing is total pressure on the machine, and several test processes share it.
+function _memory_over_threshold(threshold::Union{Nothing,Float64})
+    threshold === nothing && return false
+    return try
+        total = Sys.total_memory()
+        total == 0 && return false
+        (1 - Sys.free_memory() / total) > threshold
+    catch err
+        false
+    end
+end
+
 function runner_loop(state::TestProcessState)
     stolen_testitem_ids = String[]
     testitems = TestItemServerProtocol.RunTestItem[]
@@ -1152,7 +1183,12 @@ function runner_loop(state::TestProcessState)
 
                 print(stderr, "\x1f3805a0ad41b54562a46add40be31ca27", "$(current_testitem.id)\"", "")
                 flush(stderr)
-                ret = run_testitem(state.endpoint, current_testitem, state.mode, state.coverage_root_uris, state)
+                arm_watchdog!(current_testitem.id, current_testitem.timeoutMs)
+                ret = try
+                    run_testitem(state.endpoint, current_testitem, state.mode, state.coverage_root_uris, state)
+                finally
+                    disarm_watchdog!()
+                end
                 print(stderr, "\x1f4031af828c3d406ca42e25628bb0aa77")
                 flush(stderr)
 
@@ -1166,6 +1202,19 @@ function runner_loop(state::TestProcessState)
                     ret[1],
                     ret[2]
                 )
+
+                # Both of these run *after* the result has been reported, so an item is
+                # never charged for the collection and a recycle can never lose a result.
+                if state.gc_between_testitems
+                    GC.gc(true)
+                end
+
+                if _memory_over_threshold(state.memory_threshold)
+                    @info "Stopping this test process: system memory use is above the configured threshold of $(state.memory_threshold). The controller will redistribute the remaining test items."
+                    flush(stderr)
+                    flush(stdout)
+                    exit(MEMORY_RECYCLE_EXIT_CODE)
+                end
             end
         end
 
@@ -1183,6 +1232,10 @@ function runner_loop(state::TestProcessState)
 end
 
 function serve(pipename, debug_pipename, error_handler=nothing)
+    # Started before anything else touches the load path: `Profile` has to be resolved
+    # while `@stdlib` is still reachable, i.e. before the first `activate_env_request`.
+    start_watchdog!()
+
     if debug_pipename!==nothing
         start_debug_backend(debug_pipename, error_handler)
     end

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -1213,6 +1213,11 @@ function runner_loop(state::TestProcessState)
                     @info "Stopping this test process: system memory use is above the configured threshold of $(state.memory_threshold). The controller will redistribute the remaining test items."
                     flush(stderr)
                     flush(stdout)
+                    # Must precede `exit`: it tears the runtime down from this thread, and
+                    # racing the watchdog while it is still in Julia code crashed the process
+                    # (an `EXCEPTION_ACCESS_VIOLATION` in the JIT on Windows) or left it
+                    # failing to exit at all, which stalled the controller's shutdown.
+                    stop_watchdog!()
                     exit(MEMORY_RECYCLE_EXIT_CODE)
                 end
             end

--- a/testprocess/TestItemServer/src/watchdog.jl
+++ b/testprocess/TestItemServer/src/watchdog.jl
@@ -91,6 +91,7 @@ function _capture_profile(prof::Module)
         t0 = time()
         while time() - t0 < WATCHDOG_PROFILE_SECONDS
             Libc.systemsleep(WATCHDOG_POLL_SECONDS)
+            GC.safepoint()  # same reason as in `_watchdog_loop`
         end
     finally
         prof.stop_timer()
@@ -163,6 +164,14 @@ end
 function _watchdog_loop()
     while true
         Libc.systemsleep(WATCHDOG_POLL_SECONDS)
+
+        # Mandatory. This loop neither allocates nor yields, and `Libc.systemsleep` is a
+        # plain `ccall`, so without an explicit safepoint the thread never becomes
+        # collectable — and `GC.gc(true)` between test items, which stops the world, blocks
+        # here forever. Verified: removing this deadlocks the test process on its first
+        # inter-item collection, which is why the watchdog cannot use a yield-free loop
+        # without one.
+        GC.safepoint()
 
         deadline = WATCHDOG_DEADLINE[]
         (deadline > 0.0 && time() >= deadline) || continue

--- a/testprocess/TestItemServer/src/watchdog.jl
+++ b/testprocess/TestItemServer/src/watchdog.jl
@@ -1,0 +1,247 @@
+# In-process hang diagnostics.
+#
+# The controller sends a `timeoutMs` deadline with every test item. We arm a watchdog just
+# short of it, so that an item which is about to be killed for running too long leaves a
+# stack behind instead of a single "timed out" line. Three constraints shape this:
+#
+#   * The watchdog must not depend on libuv. When a test item wedges the main thread no
+#     thread services the event loop any more, so `sleep`, `Timer` and socket writes never
+#     complete. The watchdog therefore paces itself with `Libc.systemsleep` (a plain OS
+#     sleep) and writes to a file through `IOStream`, which is a blocking `write(2)` and
+#     needs no running loop.
+#   * The watchdog must not share a thread with the test item. The launch reserves two
+#     interactive threads on Julia >= 1.9 (see `src/testprocess.jl`): the main task — and
+#     therefore the runner loop and every test item — sits on the first, and this watchdog
+#     runs on the second.
+#   * It cannot help against an item that neither allocates nor yields. Such an item never
+#     reaches a GC safepoint, so the watchdog's first allocation blocks behind a GC that
+#     can never start. The controller's own timeout remains the backstop for that case.
+#
+# The dump goes to a file of its own rather than to stderr: a `Profile.print` is far larger
+# than the 4 KiB POSIX pipes guarantee to write atomically (and Windows named pipes
+# guarantee nothing), so sharing the captured-output stream with a test item that is still
+# printing would shred both. One writer, one file, no framing needed. The controller reads
+# the file when its own timeout fires and attributes the contents to whichever item the
+# process was running.
+
+# Set by the controller on the test process launch; absent means diagnostics are disabled.
+const DIAGNOSTICS_FILE_ENV_VAR = "JULIA_TESTITEMSERVER_DIAGNOSTICS_FILE"
+
+# Fire this far ahead of the controller's deadline. The real margin comes from the grace
+# period the controller adds before it kills the process; this only avoids racing it.
+const WATCHDOG_LEAD_MS = 250.0
+
+# Granularity of the watchdog's own sleep, and how long we let the sampler run.
+const WATCHDOG_POLL_SECONDS = 0.05
+const WATCHDOG_PROFILE_SECONDS = 1.0
+
+const WATCHDOG_FILE = Ref{Union{Nothing,String}}(nothing)
+const WATCHDOG_PROFILE = Ref{Union{Nothing,Module}}(nothing)
+# `time()` at which to dump, or 0.0 when disarmed. Written by the runner loop, read by the
+# watchdog thread; a torn read would at worst dump early or late.
+const WATCHDOG_DEADLINE = Ref{Float64}(0.0)
+const WATCHDOG_ITEM_ID = Ref{String}("")
+const WATCHDOG_ITEM_TIMEOUT_MS = Ref{Float64}(0.0)
+const WATCHDOG_RUNNING = Ref{Bool}(false)
+
+function _init_watchdog_globals!()
+    WATCHDOG_FILE[] = nothing
+    WATCHDOG_PROFILE[] = nothing
+    WATCHDOG_DEADLINE[] = 0.0
+    WATCHDOG_ITEM_ID[] = ""
+    WATCHDOG_ITEM_TIMEOUT_MS[] = 0.0
+    WATCHDOG_RUNNING[] = false
+    return nothing
+end
+
+# `Profile` is a stdlib, but the test process runs in a pinned environment
+# (`testprocess/environments/v*`) whose manifest does not list it, so `import Profile` in
+# this package would not resolve. Loading it by name against the load path stack does —
+# `@stdlib` is still on it at startup, before any test environment is activated. If that
+# ever stops being true we degrade to a text-only dump instead of failing.
+function _load_profile_module()
+    return try
+        Base.require(Main, :Profile)
+    catch err
+        @debug "Profile is not loadable in this test process; hang diagnostics will be text only" exception=err
+        nothing
+    end
+end
+
+function _write_diagnostics(text::AbstractString)
+    file = WATCHDOG_FILE[]
+    file === nothing && return nothing
+    try
+        open(file, "a") do io
+            write(io, text)
+            flush(io)
+        end
+    catch err
+        # There is nothing to fall back to: this path exists precisely because the normal
+        # channels may be unusable.
+    end
+    return nothing
+end
+
+function _capture_profile(prof::Module)
+    prof.init(n = 10^7, delay = 0.005)
+    prof.clear()
+    prof.start_timer()
+    try
+        t0 = time()
+        while time() - t0 < WATCHDOG_PROFILE_SECONDS
+            Libc.systemsleep(WATCHDOG_POLL_SECONDS)
+        end
+    finally
+        prof.stop_timer()
+    end
+
+    io = IOContext(IOBuffer(), :displaysize => (24, 200))
+    # `groupby` only exists from Julia 1.8 on, and `print` warns about empty groups and
+    # about Windows sampling only the main thread — neither belongs in a test item's output.
+    Logging.with_logger(Logging.NullLogger()) do
+        try
+            prof.print(io; groupby = :thread, C = false, maxdepth = 40)
+        catch err
+            prof.print(io; C = false, maxdepth = 40)
+        end
+    end
+    return String(take!(io.io))
+end
+
+function _memory_summary()
+    return try
+        free = Sys.free_memory() / 2^30
+        total = Sys.total_memory() / 2^30
+        live = Base.gc_live_bytes() / 2^30
+        string(round(live, digits = 2), " GiB live, ", round(free, digits = 2), " of ",
+            round(total, digits = 2), " GiB system memory free")
+    catch err
+        "unavailable"
+    end
+end
+
+function _thread_summary()
+    return @static if VERSION >= v"1.9"
+        string(Threads.nthreads(:default), " default + ", Threads.nthreads(:interactive), " interactive")
+    else
+        string(Threads.nthreads())
+    end
+end
+
+function _build_dump(testitem_id::AbstractString, timeout_ms::Float64)
+    io = IOBuffer()
+    rule = "─"^78
+    println(io)
+    println(io, rule)
+    println(io, "Hang diagnostics for test item '", testitem_id, "'")
+    println(io, "Captured by the test process watchdog because the item was still running ",
+        round(timeout_ms / 1000, digits = 1), "s into its timeout.")
+    println(io, "Julia ", VERSION, " on ", Sys.MACHINE, ", pid ", getpid(), ", threads: ", _thread_summary())
+    println(io, "Memory: ", _memory_summary())
+    println(io, rule)
+
+    prof = WATCHDOG_PROFILE[]
+    if prof === nothing
+        println(io, "No CPU profile: the Profile stdlib is not loadable in this test process.")
+    else
+        try
+            profile_text = _capture_profile(prof)
+            if isempty(strip(profile_text))
+                println(io, "No CPU profile: the sampler collected no snapshots.")
+            else
+                print(io, profile_text)
+            end
+        catch err
+            println(io, "No CPU profile: capturing one failed with ", sprint(showerror, err))
+        end
+    end
+    println(io, rule)
+    return String(take!(io))
+end
+
+function _watchdog_loop()
+    while true
+        Libc.systemsleep(WATCHDOG_POLL_SECONDS)
+
+        deadline = WATCHDOG_DEADLINE[]
+        (deadline > 0.0 && time() >= deadline) || continue
+
+        # Disarm before dumping: one dump per armed item, however long the dump takes.
+        WATCHDOG_DEADLINE[] = 0.0
+        testitem_id = WATCHDOG_ITEM_ID[]
+        timeout_ms = WATCHDOG_ITEM_TIMEOUT_MS[]
+
+        try
+            _write_diagnostics(_build_dump(testitem_id, timeout_ms))
+        catch err
+            # Deliberately swallowed — a failing watchdog must not take the process down.
+        end
+    end
+end
+
+"""
+    start_watchdog!()
+
+Load the diagnostics file path and the `Profile` module and start the watchdog thread.
+Returns `true` when the watchdog is running. Called once, at test process startup, while
+the process is still healthy.
+"""
+function start_watchdog!()
+    _init_watchdog_globals!()
+
+    file = get(ENV, DIAGNOSTICS_FILE_ENV_VAR, "")
+    isempty(file) && return false
+    WATCHDOG_FILE[] = file
+    WATCHDOG_PROFILE[] = _load_profile_module()
+
+    @static if VERSION >= v"1.9"
+        # Preferred: our own interactive thread, which the default pool cannot starve.
+        if Threads.nthreads(:interactive) >= 2
+            Threads.@spawn :interactive _watchdog_loop()
+            WATCHDOG_RUNNING[] = true
+            return true
+        end
+    end
+
+    @static if VERSION >= v"1.3"
+        # Fallback: any spare thread. Weaker, because a test item that saturates the
+        # default pool can keep the watchdog off the CPU.
+        if Threads.nthreads() >= 2
+            Threads.@spawn _watchdog_loop()
+            WATCHDOG_RUNNING[] = true
+            return true
+        end
+    end
+
+    @debug "No spare thread for the hang watchdog; timeouts will not produce a diagnostic dump"
+    return false
+end
+
+"""
+    arm_watchdog!(testitem_id, timeout_ms)
+
+Schedule a diagnostic dump shortly before `timeout_ms` from now. A `missing` timeout — the
+controller did not set one for this item — disarms instead.
+"""
+function arm_watchdog!(testitem_id::AbstractString, timeout_ms::Union{Missing,Float64})
+    if !WATCHDOG_RUNNING[] || timeout_ms === missing || timeout_ms <= 0
+        WATCHDOG_DEADLINE[] = 0.0
+        return nothing
+    end
+
+    WATCHDOG_ITEM_ID[] = String(testitem_id)
+    WATCHDOG_ITEM_TIMEOUT_MS[] = timeout_ms
+    WATCHDOG_DEADLINE[] = time() + max(0.0, timeout_ms - WATCHDOG_LEAD_MS) / 1000
+    return nothing
+end
+
+"""
+    disarm_watchdog!()
+
+Cancel any pending dump. Cheap enough to call unconditionally after every test item.
+"""
+function disarm_watchdog!()
+    WATCHDOG_DEADLINE[] = 0.0
+    return nothing
+end

--- a/testprocess/TestItemServer/src/watchdog.jl
+++ b/testprocess/TestItemServer/src/watchdog.jl
@@ -43,6 +43,9 @@ const WATCHDOG_DEADLINE = Ref{Float64}(0.0)
 const WATCHDOG_ITEM_ID = Ref{String}("")
 const WATCHDOG_ITEM_TIMEOUT_MS = Ref{Float64}(0.0)
 const WATCHDOG_RUNNING = Ref{Bool}(false)
+# Asks the watchdog thread to leave its loop. Set before a deliberate `exit`, so the runtime
+# is not torn down while another thread is still running Julia code — see `stop_watchdog!`.
+const WATCHDOG_STOP = Ref{Bool}(false)
 
 function _init_watchdog_globals!()
     WATCHDOG_FILE[] = nothing
@@ -51,6 +54,7 @@ function _init_watchdog_globals!()
     WATCHDOG_ITEM_ID[] = ""
     WATCHDOG_ITEM_TIMEOUT_MS[] = 0.0
     WATCHDOG_RUNNING[] = false
+    WATCHDOG_STOP[] = false
     return nothing
 end
 
@@ -162,7 +166,7 @@ function _build_dump(testitem_id::AbstractString, timeout_ms::Float64)
 end
 
 function _watchdog_loop()
-    while true
+    while !WATCHDOG_STOP[]
         Libc.systemsleep(WATCHDOG_POLL_SECONDS)
 
         # Mandatory. This loop neither allocates nor yields, and `Libc.systemsleep` is a
@@ -187,6 +191,9 @@ function _watchdog_loop()
             # Deliberately swallowed — a failing watchdog must not take the process down.
         end
     end
+    # Lets `stop_watchdog!` see that this thread is out of Julia code before the caller exits.
+    WATCHDOG_RUNNING[] = false
+    return nothing
 end
 
 """
@@ -252,5 +259,30 @@ Cancel any pending dump. Cheap enough to call unconditionally after every test i
 """
 function disarm_watchdog!()
     WATCHDOG_DEADLINE[] = 0.0
+    return nothing
+end
+
+"""
+    stop_watchdog!()
+
+Ask the watchdog thread to leave its loop and wait briefly for it to do so.
+
+Call this before any deliberate `exit` from the runner loop. `exit` tears the runtime down
+from the calling thread, and if the watchdog is still executing Julia code — a safepoint, an
+allocation, a JIT-compiled frame — that teardown races it. On Windows that surfaced as an
+`EXCEPTION_ACCESS_VIOLATION` inside the JIT; elsewhere it showed up as the process failing
+to exit at all, which stalled controller shutdown.
+"""
+function stop_watchdog!()
+    WATCHDOG_DEADLINE[] = 0.0
+    WATCHDOG_STOP[] = true
+    WATCHDOG_RUNNING[] || return nothing
+
+    # One poll interval is enough for the loop to observe the flag; the small margin covers
+    # a thread that was mid-sleep when it was set.
+    deadline = time() + 10 * WATCHDOG_POLL_SECONDS
+    while WATCHDOG_RUNNING[] && time() < deadline
+        Libc.systemsleep(WATCHDOG_POLL_SECONDS)
+    end
     return nothing
 end


### PR DESCRIPTION
Stream S4 of the ReTestItems parity plan. Fourth in the stack: #38 -> #39 -> #40 -> **#41**.

## Hang diagnostics

The controller sends `timeoutMs` with each item; the test process arms a watchdog just short of it and dumps a CPU profile plus a memory/thread summary, so a timed-out item leaves a stack behind instead of one "timed out" line. Three constraints shaped it:

- **No libuv.** A test item that wedges the main thread stops the event loop, so `sleep`, `Timer` and socket writes never complete. The watchdog paces itself with `Libc.systemsleep` and writes through a blocking `IOStream`.
- **Its own thread.** The launch reserves two interactive threads on Julia >= 1.9; the runner loop and every test item sit on the first, the watchdog on the second.
- **Its own file, not stderr.** A `Profile.print` far exceeds the 4 KiB POSIX pipes guarantee atomically (Windows named pipes guarantee nothing), so sharing the captured-output stream with a still-printing test item would shred both. One writer, one file, no framing. The controller folds it into the item's output when its own timeout fires.

`Profile` is loaded via `Base.require(Main, :Profile)` because the pinned worker environments don't list it; if that ever fails we degrade to a text-only dump.

Documented limitation: an item that neither allocates nor yields never reaches a safepoint, so the watchdog's first allocation blocks behind a GC that cannot start. The controller's timeout remains the backstop.

## GC and memory recycling

`GC.gc(true)` after each item, on by default when a run has more than one process. For memory, the controller cannot check before dispatch the way ReTestItems does — we send whole batches and the worker loops internally — so the worker checks after each item and exits cleanly with code 66. The controller redistributes un-started items through the existing termination path. Both run *after* the result is reported, so an item is never charged for the collection and a recycle cannot lose a result.

## The deadlock this shipped with

`_watchdog_loop` neither allocated nor yielded, and `Libc.systemsleep` is a plain `ccall`, so the watchdog thread never became collectable. `GC.gc(true)` stops the world and waits for every thread — so the first inter-item collection blocked forever. The process stopped consuming items and the run wedged. Because `gc_between_testitems` defaults on for multi-worker runs, this was the common path, not an edge case. Fixed with `GC.safepoint()` in both yield-free loops.

## Diagnostics fix

A clean memory recycle was logged as "redistributing un-started item(s) from **crashed** process", plus a spurious second "terminated after running items" line. Redistribution was always correct; only the diagnostics lied — in the one path this feature exists to keep readable.

## Tests

**171/171** via the MCP tools. Four new tests cover the three features, which originally shipped untested because the run meant to write them hit the deadlock above.

Two were checked against a broken implementation rather than assumed meaningful:

- the GC test **errors at the run timeout** with `GC.safepoint()` removed from `_watchdog_loop`, and passes in ~25s with it;
- the memory-recycle test asserts more than one process was created — without that it would pass whether or not a single recycle fired.

Note for CI: several tests spawn nested controllers and test processes, so they are sensitive to outer parallelism. At `max_workers=3` an unrelated item occasionally exceeds its per-item timeout; `max_workers=2` runs the suite green in ~7.5 min. `test_julia_versions.jl` alone needs ~278s because it launches `julia +1.4` workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)