### PR TITLE
TestEnv: port merge-project guard to Julia <=1.10 variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 Manifest.toml
 *.log
 docs/build
+
+# Fixture for the TestEnv merge-project guard: the test manifest is the point of the test.
+!testdata/TestManifestPackage/test/Manifest.toml

--- a/packages/TestEnv/src/julia-1.4/activate_set.jl
+++ b/packages/TestEnv/src/julia-1.4/activate_set.jl
@@ -37,7 +37,8 @@ function activate(pkg::AbstractString=current_pkg_name())
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/packages/TestEnv/src/julia-1.7/activate_set.jl
+++ b/packages/TestEnv/src/julia-1.7/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name())
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/packages/TestEnv/src/julia-1.8/activate_set.jl
+++ b/packages/TestEnv/src/julia-1.8/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/packages/TestEnv/src/julia-1.9/activate_set.jl
+++ b/packages/TestEnv/src/julia-1.9/activate_set.jl
@@ -39,7 +39,8 @@ function activate(pkg::AbstractString=current_pkg_name(); allow_reresolve=true)
         if entry !== nothing && isfixed(entry)
             subgraph = Pkg.Operations.prune_manifest(sandbox_manifest, [uuid])
             for (uuid, entry) in subgraph
-                if haskey(working_manifest, uuid)
+                entry_working = get(working_manifest, uuid, nothing)
+                if entry_working !== nothing && entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
                     Pkg.Operations.pkgerror("can not merge projects")
                 end
                 working_manifest[uuid] = entry

--- a/test/test_test_manifest.jl
+++ b/test/test_test_manifest.jl
@@ -1,0 +1,51 @@
+# Regression test for a package whose `test/Manifest.toml` lists the package itself as a
+# `path = ".."` dev entry (the layout `Pkg.develop(path=".")` inside `test/` produces).
+#
+# TestEnv merges the test manifest into the package's own manifest and used to error with
+# "can not merge projects" on Julia <= 1.10 when the package's uuid was already present, see
+# julia-vscode/julia-vscode#3832 and #3633. The Julia 1.11+ variant of the vendored TestEnv
+# already tolerated that; the older variants carry the same guard now.
+
+@testitem "Package with test/Manifest.toml dev-ing itself activates" setup=[TestHelpers] begin
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "TestManifestPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+    @test length(discovered.items) == 1
+
+    result = TestHelpers.run_testrun(discovered)
+
+    passed_events = filter(e -> e.event == :passed, result.events)
+    errored_events = filter(e -> e.event == :errored, result.events)
+    failed_events = filter(e -> e.event == :failed, result.events)
+
+    @test length(passed_events) == 1
+    @test length(errored_events) == 0
+    @test length(failed_events) == 0
+end
+
+# Same fixture on Julia 1.10, the newest release that runs the pre-1.11 TestEnv variant
+# where the guard was missing.
+@testitem "Package with test/Manifest.toml dev-ing itself activates on Julia 1.10" tags=[:comprehensive_platform] setup=[TestHelpers] begin
+    version = "1.10"
+    version in TestHelpers.installed_juliaup_channels() ||
+        error("Julia $version is not installed. Install it with: juliaup add $version")
+
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "TestManifestPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+    @test length(discovered.items) == 1
+
+    result = TestHelpers.run_testrun(
+        discovered;
+        julia_cmd="julia",
+        julia_args=["+$version"],
+        timeout=1800,
+        env=TestHelpers.isolated_depot_env(version)
+    )
+
+    passed_events = filter(e -> e.event == :passed, result.events)
+    errored_events = filter(e -> e.event == :errored, result.events)
+    failed_events = filter(e -> e.event == :failed, result.events)
+
+    @test length(passed_events) == 1
+    @test length(errored_events) == 0
+    @test length(failed_events) == 0
+end

--- a/testdata/TestManifestPackage/Project.toml
+++ b/testdata/TestManifestPackage/Project.toml
@@ -1,0 +1,3 @@
+name = "TestManifestPackage"
+uuid = "a1b2c3d4-0001-0002-0003-000000000005"
+version = "0.1.0"

--- a/testdata/TestManifestPackage/src/TestManifestPackage.jl
+++ b/testdata/TestManifestPackage/src/TestManifestPackage.jl
@@ -1,0 +1,7 @@
+module TestManifestPackage
+
+export add
+
+add(a, b) = a + b
+
+end

--- a/testdata/TestManifestPackage/test/Manifest.toml
+++ b/testdata/TestManifestPackage/test/Manifest.toml
@@ -1,0 +1,44 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.12"
+manifest_format = "2.0"
+project_hash = "384635e1de875781e73ceb2aa94e5daeb20cc464"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.TestItems]]
+git-tree-sha1 = "a6dd904babc04670c784f81b67957a3545271610"
+uuid = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
+version = "1.1.0"
+
+[[deps.TestManifestPackage]]
+path = ".."
+uuid = "a1b2c3d4-0001-0002-0003-000000000005"
+version = "0.1.0"

--- a/testdata/TestManifestPackage/test/Project.toml
+++ b/testdata/TestManifestPackage/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
+TestManifestPackage = "a1b2c3d4-0001-0002-0003-000000000005"

--- a/testdata/TestManifestPackage/test/testitems.jl
+++ b/testdata/TestManifestPackage/test/testitems.jl
@@ -1,0 +1,4 @@
+@testitem "add works" begin
+    using TestManifestPackage
+    @test add(1, 2) == 3
+end


### PR DESCRIPTION
## Summary

- The Julia 1.11+ variant of the vendored TestEnv (`packages/TestEnv/src/julia-1.11/activate_set.jl`) guards the "can not merge projects" error: it only fires when the working manifest already holds a *different* entry for the uuid and that uuid is not the package under test. The `julia-1.4/1.7/1.8/1.9` variants still had the unguarded `haskey(working_manifest, uuid)` check, so a package with a `test/Manifest.toml` that lists the package itself as a `path = ".."` dev entry (the layout `Pkg.develop(path=".")` inside `test/` produces) failed activation on Julia <= 1.10 test processes with `can not merge projects`. Fixes the TIC side of julia-vscode/julia-vscode#3832 and julia-vscode/julia-vscode#3633.
- Port the 1.11 guard to the four older variants (`prune_manifest(sandbox_manifest, [uuid])` kept as-is; the `Set([uuid])` form is 1.12+ only). `julia-1.0..1.3` do not contain the pattern and are untouched.
- New fixture `testdata/TestManifestPackage` (package + `test/Project.toml` + committed `test/Manifest.toml` format 2.0 dev-ing the package via `path = ".."`; `.gitignore` gets a negation for that one manifest) and `test/test_test_manifest.jl` with two test items: one running the fixture on the current Julia, one tagged `:comprehensive_platform` running it on the Julia 1.10 juliaup channel via `TestHelpers.isolated_depot_env`, like `test_julia_versions.jl`.

Same change proposed upstream at JuliaTesting/TestEnv.jl (see linked PR).

## Test plan

- [x] Direct reproducer with Julia 1.10.12: `TestEnv.activate()` on the fixture fails with `can not merge projects` using the vendored copy on `main`, succeeds with this branch.
- [x] `test/test_test_manifest.jl` (both items, i.e. current Julia 1.12.7 and Julia 1.10.12 test process) and `test/test_run_passing.jl` run locally via `TestItemRunner.run_tests` with a filename filter: 16/16 pass.
- [ ] Full CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
