### PR TITLE
Release a test item's globals when it finishes

### DIFF
--- a/test/test_memory_release.jl
+++ b/test/test_memory_release.jl
@@ -1,0 +1,83 @@
+@testitem "Test item globals are released when the item finishes" setup=[TestHelpers] begin
+    # A test item runs in a module of its own, and Julia cannot unload a module: without
+    # the teardown in `release_module_globals!` everything the item bound to a global stays
+    # reachable for the life of the test process, which is what
+    # julia-testitems/TestItemRunner.jl#65 reports.
+    #
+    # The fixture's first item parks a `WeakRef` to a large array in `Main` — `Main` is not
+    # a test code module, so the teardown leaves the probe itself alone — and its second
+    # item collects and looks at what the reference still points at. They have to run in
+    # this order on the same process, so they are driven as two consecutive runs rather
+    # than as one run of two items.
+    using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown, ControllerCallbacks
+    import UUIDs
+
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "MemoryPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    bind_items = filter(i -> i.label == "memory probe: bind", discovered.items)
+    check_items = filter(i -> i.label == "memory probe: check", discovered.items)
+    @test length(bind_items) == 1
+    @test length(check_items) == 1
+
+    process_created_ids = String[]
+    pc_lock = ReentrantLock()
+
+    results = NamedTuple[]
+    results_lock = ReentrantLock()
+
+    callbacks = ControllerCallbacks(
+        on_testitem_started = (run_id, item_id, test_env_id) -> nothing,
+        on_testitem_passed = (run_id, item_id, test_env_id, duration) -> lock(results_lock) do
+            push!(results, (event=:passed, testitem_id=item_id))
+        end,
+        on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> lock(results_lock) do
+            push!(results, (event=:failed, testitem_id=item_id, messages=messages))
+        end,
+        on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> lock(results_lock) do
+            push!(results, (event=:errored, testitem_id=item_id, messages=messages))
+        end,
+        on_testitem_skipped = (run_id, item_id, test_env_id) -> nothing,
+        on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
+        on_attach_debugger = (run_id, pipe_name) -> nothing,
+        on_process_created = (id, test_env_id) -> lock(pc_lock) do
+            push!(process_created_ids, id)
+        end,
+    )
+
+    controller = TestItemController(callbacks)
+    test_env = TestHelpers.make_test_environment(; TestHelpers._env_kwargs(discovered)...)
+
+    controller_task = @async try
+        run(controller)
+    catch err
+        @error "Controller error" exception=(err, catch_backtrace())
+    end
+
+    try
+        for items in (bind_items, check_items)
+            execute_testrun(
+                controller,
+                string(UUIDs.uuid4()),
+                [test_env],
+                items,
+                [TestRunItem(i.id, test_env.id, nothing, :Info) for i in items],
+                discovered.setups,
+                1,
+                nothing
+            )
+        end
+    finally
+        shutdown(controller)
+        TestHelpers.timed_wait(controller_task, 600; label="memory-release-controller")
+    end
+
+    # Both items must have run on the same process, or the probe proves nothing
+    @test lock(pc_lock) do; length(process_created_ids) end == 1
+
+    events = lock(results_lock) do; copy(results) end
+    @test length(events) == 2
+    # The second item is the assertion: it fails if the array the first item bound is still
+    # reachable after a full collection
+    @test all(e -> e.event == :passed, events)
+end

--- a/testdata/MemoryPackage/Project.toml
+++ b/testdata/MemoryPackage/Project.toml
@@ -1,0 +1,3 @@
+name = "MemoryPackage"
+uuid = "a1b2c3d4-0001-0002-0003-000000000006"
+version = "0.1.0"

--- a/testdata/MemoryPackage/src/MemoryPackage.jl
+++ b/testdata/MemoryPackage/src/MemoryPackage.jl
@@ -1,0 +1,5 @@
+module MemoryPackage
+
+greet() = "Hello from MemoryPackage!"
+
+end # module MemoryPackage

--- a/testdata/MemoryPackage/test/memory_tests.jl
+++ b/testdata/MemoryPackage/test/memory_tests.jl
@@ -1,0 +1,27 @@
+# Probes for the module teardown that frees whatever a test item bound to a global.
+#
+# Every test item runs in a module of its own, and Julia cannot unload a module, so
+# without the teardown the array below stays reachable for the life of the test process
+# (julia-testitems/TestItemRunner.jl#65).
+#
+# The two items have to run in this order on the same test process, which is why the test
+# drives them as two consecutive test runs rather than as one run of two items: the
+# controller keeps its remaining work in a `Dict`, so the order within a single run is not
+# something a test can rely on.
+#
+# The probe lives in `Main` rather than in the item's own module precisely because `Main`
+# is what the teardown does *not* touch.
+
+@testitem "memory probe: bind" begin
+    leaked = zeros(UInt8, 8_000_000)
+    Core.eval(Main, :(MEMORY_PROBE = $(WeakRef(leaked))))
+    @test length(leaked) == 8_000_000
+end
+
+@testitem "memory probe: check" begin
+    GC.gc(true)
+    GC.gc(true)
+
+    @test isdefined(Main, :MEMORY_PROBE)
+    @test Main.MEMORY_PROBE.value === nothing
+end

--- a/testdata/MemoryPackage/test/runtests.jl
+++ b/testdata/MemoryPackage/test/runtests.jl
@@ -1,0 +1,3 @@
+using TestItemRunner
+
+@run_package_tests

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -426,10 +426,65 @@ end
 # the closing parenthesis.
 parenthesized_skip_code(skip::AbstractString) = string("(\n", skip, "\n)")
 
+"""
+    release_module_globals!(mod)
+
+Point every global in `mod` at `nothing`, so that whatever the test item bound to one
+becomes collectable.
+
+Every test item runs in a module of its own, and Julia cannot unload a module: the module
+stays reachable for the life of the test process, and so does everything its globals point
+at. A test item that binds a large array therefore keeps that array alive for every later
+item on the same process, which is what julia-testitems/TestItemRunner.jl#65 reports. The
+module object itself still leaks — nothing can be done about that — but its contents do
+not have to.
+
+Left alone: `eval`, `include` and the module's own name, which the `module` expression
+created rather than the test item, and submodules, because a `@testmodule` reached through
+one is shared with other test items. Bindings that cannot take `nothing` — a `const` on
+Julia before 1.12, a typed global, a name brought in by `using` — are skipped as they come
+up, because there is nothing else to try for them.
+"""
+function release_module_globals!(mod::Module)
+    for name in names(mod; all=true)
+        (name === :eval || name === :include || name === nameof(mod)) && continue
+        # Names Julia generated itself, for closures, generators and macro hygiene
+        occursin('#', string(name)) && continue
+        isdefined(mod, name) || continue
+
+        try
+            getfield(mod, name) isa Module && continue
+            # `Core.eval` rather than `setglobal!`, which only exists from Julia 1.9 on
+            Core.eval(mod, Expr(:(=), name, nothing))
+        catch
+        end
+    end
+
+    return nothing
+end
+
 # `testcode_module_parent` exists for the precompile workload: during package-image
 # generation `Main` is closed, so the throwaway module holding the test code must be
 # created inside the (still open) TestItemServer module instead.
 function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode::String, coverage_root_uris::Union{Nothing,Vector{String}}, state::TestProcessState; testcode_module_parent::Module=Main)
+    # The modules created for this test item, emptied once it is done with them. They are
+    # collected here rather than cleared where they are created because `_run_testitem`
+    # returns from a dozen places.
+    testcode_modules = Module[]
+
+    try
+        return _run_testitem(endpoint, params, mode, coverage_root_uris, state, testcode_modules; testcode_module_parent=testcode_module_parent)
+    finally
+        for m in testcode_modules
+            # `invokelatest` is load bearing: the test item's globals were created by an
+            # `include_string` in a newer world, and from this one `names(m; all=true)`
+            # does not list them yet, so a direct call would find nothing to release.
+            Base.invokelatest(release_module_globals!, m)
+        end
+    end
+end
+
+function _run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode::String, coverage_root_uris::Union{Nothing,Vector{String}}, state::TestProcessState, testcode_modules::Vector{Module}; testcode_module_parent::Module=Main)
     JSONRPC.send(
         endpoint,
         TestItemServerProtocol.started_notification_type,
@@ -453,6 +508,7 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
 
         try
             skip_module = Core.eval(testcode_module_parent, :(module $(gensym()) end))
+            push!(testcode_modules, skip_module)
             skip_result = Base.invokelatest(
                 include_string,
                 skip_module,
@@ -610,6 +666,7 @@ function run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mode
     end
 
     mod = Core.eval(testcode_module_parent, :(module $(gensym()) end))
+    push!(testcode_modules, mod)
 
     if params.useDefaultUsings
         try


### PR DESCRIPTION
Part of julia-testitems/TestItemRunner.jl#65 (the `@run_package_tests` half will be a matching PR on TestItemRunner.jl).

Every test item runs in a module of its own, and Julia cannot unload a module: the module stays reachable for the life of the test process, and so does everything the item bound to a global. Running a test item that allocates a large array a few times over on the same process therefore fills memory — the reporter's case is `a = ones(1000, 1000, 1000)`.

The module object itself still leaks; nothing can be done about that. Its contents do not have to. Once the item is done, `release_module_globals!` points every global in its module at `nothing`.

Left alone:
- `eval`, `include` and the module's own name — the `module` expression created those, not the test item;
- submodules, because a `@testmodule` reached through one is shared with other test items;
- bindings that cannot take `nothing` (a `const` on Julia before 1.12, a typed global, a name brought in by `using`) — those are skipped as they come up, since there is nothing else to try for them.

One thing worth flagging for review: the teardown has to go through `invokelatest`. The item's globals are created by an `include_string` in a newer world, and from the world `run_testitem` runs in, `names(m; all=true)` does not list them yet — a direct call finds nothing to release and silently does nothing. That cost me most of the debugging on this one.

The new test drives the `MemoryPackage` fixture as two consecutive test runs on one process rather than as one run of two items, because the controller keeps its remaining work in a `Dict` and the order within a single run is not something a test can rely on. The first item parks a `WeakRef` to an 8 MB array in `Main` — `Main` is not a test code module, so the teardown leaves the probe itself alone — and the second collects and checks that the reference has gone dead.

Full suite green: 201/201, including the Julia 1.0–1.13 version matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
