### PR TITLE
Reattach the TestItemController docstring

### DIFF
--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -1,3 +1,7 @@
+# Shutdown normally completes as soon as every process has reported its termination — a
+# few hundred milliseconds. This is the backstop for the case where one never does.
+const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0
+
 """
     TestItemController(callbacks; error_handler_file=nothing, crash_reporting_pipename=nothing, log_level=:Info)
 
@@ -34,10 +38,6 @@ the reactor event loop, then use [`execute_testrun`](@ref) to submit work.
 See also [`ControllerCallbacks`](@ref), [`execute_testrun`](@ref), [`shutdown`](@ref),
 [`wait_for_shutdown`](@ref).
 """
-# Shutdown normally completes as soon as every process has reported its termination — a
-# few hundred milliseconds. This is the backstop for the case where one never does.
-const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0
-
 mutable struct TestItemController{CB<:ControllerCallbacks}
     callbacks::CB
 


### PR DESCRIPTION
`deploy-docs` has been failing on main and on every open PR:

```
no docs found for 'TestItemControllers.TestItemController' in `@docs` block in docs/src/julia-api.md:69-71
Cannot resolve @ref for md"[`TestItemController`](@ref)" in docs/src/jsonrpc-api.md.
Cannot resolve @ref for md"[`TestItemController`](@ref)" in docs/src/julia-api.md.
Cannot resolve @ref for md"[`TestItemController`](@ref)" in docs/src/index.md.
ERROR: LoadError: `makedocs` encountered errors [:docs_block, :cross_references]
```

`const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0` was added between the docstring and the struct it documents, so the docstring attached to the const and `TestItemController` — the package's main entry point — ended up with none.

Moving the const above the docstring puts the docstring back next to the struct. No other change.

Verified by building the docs locally: `makedocs` now gets all the way through `RenderDocument`/`HTMLWriter` instead of terminating on `:docs_block` and `:cross_references`. The remaining "134 docstrings not included in the manual" message is a pre-existing warning, not an error.

Merging this turns `deploy-docs` green on main and on #61, #62 and #63 at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
