### PR TITLE
Give the per-version platform items' own timeout room to fire

### DIFF
--- a/.github/workflows/juliaci.yml
+++ b/.github/workflows/juliaci.yml
@@ -15,6 +15,11 @@ jobs:
       include-beta-versions: true
       filter: 'dirname(filename) == joinpath(pwd(), "test")'
       github_job_prep_script: 'scripts/install_julia_versions.jl'
+      # Above the 1800s budget that TestHelpers.check_julia_version gives its nested run
+      # (plus its 60s shutdown wait), so that a stalled per-version item is caught by that
+      # guard — which dumps what every nested test process was doing — instead of being cut
+      # down first by the runner's own per-item deadline, which reports only a bare timeout.
+      testitem-timeout: 2400
     permissions: write-all
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -99,6 +99,18 @@
         end
     end
 
+    # This is dominated by juliaup fetching an old toolchain and that Julia precompiling into
+    # a fresh depot, which is unbounded on a slow runner — the 32-bit Windows leg times out at
+    # 600s. The deadline is here to catch a hang, not to hold the toolchain to a performance
+    # budget.
+    #
+    # It must stay *below* the per-item deadline the runner executing this suite imposes,
+    # which .github/workflows/juliaci.yml sets to 2400s. Above it, the runner kills the item
+    # first and `run_testrun`'s dump of what every nested test process was doing — the whole
+    # point of having a guard here — never runs. That inversion is how a stalled `Julia 1.10
+    # platform` item on macOS once reported nothing but a bare timeout.
+    const PLATFORM_RUN_TIMEOUT = 1800
+
     """
         check_julia_version(version)
 
@@ -123,11 +135,7 @@
             items, discovered.setups, discovered;
             julia_cmd="julia",
             julia_args=["+$version"],
-            # This is dominated by juliaup fetching an old toolchain and that Julia
-            # precompiling into a fresh depot, which is unbounded on a slow runner — the
-            # 32-bit Windows leg times out at 600s. The deadline is here to catch a hang,
-            # not to hold the toolchain to a performance budget.
-            timeout=1800,
+            timeout=PLATFORM_RUN_TIMEOUT,
             env=isolated_depot_env(version)
         )
 


### PR DESCRIPTION
`TestHelpers.check_julia_version` guards its nested run with `timeout=1800`, generous on purpose — the budget is dominated by juliaup fetching an old toolchain and that Julia precompiling into a fresh depot, and the 32-bit Windows leg had already overrun 600s. On a stall the guard shuts the nested controller down and calls `dump_process_output()`, which prints what every nested test process was doing. That is the only way to tell a slow toolchain apart from a wedged one.

**The guard could never fire.** The runner executing this suite kills a test item at its own per-item deadline, and `julia-run-testitems` defaults that to 1200s. `.github/workflows/juliaci.yml` never overrode it, so 1200 < 1800 and the runner always won.

That is what [run 32299598241](https://github.com/julia-testitems/TestItemControllers.jl/actions/runs/32299598241/job/96218896477) hit on `macos-26 / 1.12.7~aarch64`:

```
┌ Warning: Test item 'Julia 1.10 platform' timed out after 1200.0 seconds
✗ test/test_julia_versions.jl:Julia 1.10 platform → errored
```

The item normally takes ~80s there. The hang dump shows the nested controller parked in `_activate_env!` waiting on a JSON-RPC reply that never came — but the nested test process's *own* output, which would say what Julia 1.10 was doing, was never dumped, because the item was already dead.

### Changes

- `testitem-timeout: 2400` in the workflow — clear of the 1800s guard plus its 60s shutdown wait. It is a top-level input of the reusable workflow and resolves for every trigger, since no `pr-`/`main-`/`draft-pr-`/`manual-trigger-` override is set here.
- The guard's budget becomes `TestHelpers.PLATFORM_RUN_TIMEOUT`, with the invariant between the two values written down at the constant rather than implied.

Raising the ceiling only changes how long a *hung* item takes to fail; nothing else in the suite comes near it (every other `run_testrun` caller uses the 600s default).

Independent of #67, which is where the failure surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)