### PR TITLE
Report an environment activation that has not finished yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- An environment activation that has not finished is now reported with a warning naming the test process and how long it has been waiting, repeating every `activation_progress_seconds` (a new `TestItemController` keyword, default 120). Activation covers the test process's own precompilation, so a slow one is legitimate and is not interrupted — but a run that stalls there no longer goes silent between the `Activating` status and whatever eventually gives up.
 - The JSON-RPC protocol gained a client → controller `shutdown` notification for a graceful shutdown: every run is cancelled, every test process is terminated (force-killed if it does not exit within the grace period) and the controller exits once they are gone.
 - `write_junit_xml(io_or_path, ::TestrunResult; root)` writes a test run as JUnit XML, the one report format every CI system ingests. Test items are grouped into one `<testsuite>` per source file and one `<testcase>` per (item × run profile); captured output goes to `<system-out>` with ANSI escape sequences stripped, and performance statistics become `<properties>`. It is a pure function of a `TestrunResult`, so a result file written by one process can be converted by another.
 - `write_lcov(io_or_path, ::TestrunResult)` writes a run's merged coverage in LCOV info format, so consumers no longer have to reach into the vendored `CoverageTools`.

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -2,6 +2,12 @@
 # few hundred milliseconds. This is the backstop for the case where one never does.
 const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0
 
+# Activating an environment normally takes seconds. When it takes minutes it is because the
+# test process is precompiling, or fetching, or wedged — and until it answers, the controller
+# has nothing to say beyond the "Activating" status it posted at the start. This is how often
+# it says so anyway.
+const DEFAULT_ACTIVATION_PROGRESS_SECONDS = 120.0
+
 """
     TestItemController(callbacks; error_handler_file=nothing, crash_reporting_pipename=nothing, log_level=:Info)
 
@@ -27,6 +33,10 @@ the reactor event loop, then use [`execute_testrun`](@ref) to submit work.
   to report its termination before force-killing whatever is left and stopping anyway
   (default 30). Shutdown normally completes well within a second; this only bounds the
   failure case.
+- `activation_progress_seconds::Real` — how often a still-unfinished environment activation
+  is reported with a warning (default 120). Activation covers the test process's own
+  precompilation, so a slow one is normal and is not interrupted; this only makes it visible
+  while it is happening instead of only in the post-mortem of whatever kills the run.
 
 # Lifecycle
 
@@ -72,6 +82,10 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
     shutdown_grace_seconds::Float64
     shutdown_timer::Union{Nothing,Timer}
 
+    # How often `_activate_env!` warns that an activation it is still waiting on has not
+    # finished.
+    activation_progress_seconds::Float64
+
     # Scheduling history, in memory and keyed by the (stable) test item id. It survives
     # across the test runs of one session; nothing is persisted to disk.
     schedule::Symbol
@@ -85,12 +99,15 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
         crash_reporting_pipename=nothing,
         log_level::Symbol=:Info,
         schedule::Symbol=:duration,
-        shutdown_grace_seconds::Real=DEFAULT_SHUTDOWN_GRACE_SECONDS) where {CB<:ControllerCallbacks}
+        shutdown_grace_seconds::Real=DEFAULT_SHUTDOWN_GRACE_SECONDS,
+        activation_progress_seconds::Real=DEFAULT_ACTIVATION_PROGRESS_SECONDS) where {CB<:ControllerCallbacks}
 
         schedule in (:duration, :contiguous) ||
             throw(ArgumentError("schedule must be :duration or :contiguous, got $(repr(schedule))"))
         shutdown_grace_seconds > 0 ||
             throw(ArgumentError("shutdown_grace_seconds must be positive, got $(shutdown_grace_seconds)"))
+        activation_progress_seconds > 0 ||
+            throw(ArgumentError("activation_progress_seconds must be positive, got $(activation_progress_seconds)"))
 
         return new{CB}(
             callbacks,
@@ -107,6 +124,7 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
             controller_fsm("controller"),
             Float64(shutdown_grace_seconds),
             nothing,
+            Float64(activation_progress_seconds),
             schedule,
             Dict{String,Symbol}(),
             Dict{String,Float64}(),
@@ -2281,15 +2299,29 @@ function _activate_env!(c::TestItemController, ps::TestProcessState)
             @debug "Activation cancelled: endpoint gone before send" testprocess_id=ps.id
             return
         end
-        result = JSONRPC.send(
-            ps.endpoint,
-            TestItemServerProtocol.testserver_activate_env_request_type,
-            TestItemServerProtocol.ActivateEnvParams(
-                projectUri = something(ps.env.project_uri, missing),
-                packageUri = ps.env.package_uri,
-                packageName = ps.env.package_name
+        # Say so, repeatedly, while this is outstanding. The request covers the test
+        # process's own precompilation, so a slow one is legitimate and is not interrupted
+        # here — but without this the controller goes silent between the "Activating" status
+        # and whatever eventually gives up, and a run that stalls in activation leaves a log
+        # that names neither the stage nor the process.
+        interval = c.activation_progress_seconds
+        started = time()
+        progress_timer = Timer(interval, interval=interval) do _
+            @warn "Environment activation still pending" testprocess_id=ps.id package=ps.env.package_name elapsed_seconds=round(time() - started, digits=1)
+        end
+        result = try
+            JSONRPC.send(
+                ps.endpoint,
+                TestItemServerProtocol.testserver_activate_env_request_type,
+                TestItemServerProtocol.ActivateEnvParams(
+                    projectUri = something(ps.env.project_uri, missing),
+                    packageUri = ps.env.package_uri,
+                    packageName = ps.env.package_name
+                )
             )
-        )
+        finally
+            close(progress_timer)
+        end
 
         if result.status == "failed"
             @warn "Environment activation failed" testprocess_id=ps.id error=coalesce(result.error, "unknown error")

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -358,7 +358,7 @@
     # the second run gets the pooled, already-warm test process of the first. `runs` in the
     # returned value holds the per-run events and output; `events`/`outputs` are the union
     # across runs, which is what a single-run caller wants.
-    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false)
+    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false, activation_progress_seconds=nothing)
         events = NamedTuple[]
         events_lock = ReentrantLock()
         push_event!(e) = lock(events_lock) do
@@ -411,7 +411,9 @@
             end
         end
 
-        controller = TestItemController(callbacks; log_level=log_level)
+        controller = activation_progress_seconds === nothing ?
+            TestItemController(callbacks; log_level=log_level) :
+            TestItemController(callbacks; log_level=log_level, activation_progress_seconds=activation_progress_seconds)
         test_env = make_test_environment(; mode=mode, julia_cmd=julia_cmd, julia_args=julia_args, env=env, package_name=package_name, package_uri=package_uri, project_uri=project_uri, env_content_hash=env_content_hash, color=color)
 
         # Build work units from items

--- a/test/test_worker_lifecycle.jl
+++ b/test/test_worker_lifecycle.jl
@@ -223,3 +223,51 @@ end
     @test isempty(controller.test_processes)
     @test controller.shutdown_timer === nothing
 end
+
+@testitem "A slow environment activation is reported while it is still running" setup=[TestHelpers] begin
+    # Activation covers the test process's own precompilation, so it can legitimately take
+    # minutes. Until it answers, the controller has nothing to say beyond the "Activating"
+    # status it posted at the start — which is how a per-version platform item that stalled
+    # in activation on macOS produced a job log naming neither the stage nor the process.
+    #
+    # The interval is dialled down to a fraction of a second so a *normal* activation, which
+    # spends well over that launching and loading the test server, trips it.
+    using Logging: with_logger, Warn
+    using Test: TestLogger
+
+    discovered = TestHelpers.basic_package_discovery()
+    items = filter(i -> i.label == "add works", discovered.items)
+    @test length(items) == 1
+
+    logger = TestLogger(min_level=Warn)
+    result = with_logger(logger) do
+        TestHelpers.run_testrun(items, discovered.setups, discovered; activation_progress_seconds=0.05)
+    end
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 1
+
+    pending = filter(r -> r.message == "Environment activation still pending", logger.logs)
+    @test !isempty(pending)
+    # It names what is slow, not just that something is.
+    @test haskey(first(pending).kwargs, :testprocess_id)
+    @test first(pending).kwargs[:elapsed_seconds] > 0
+end
+
+@testitem "activation_progress_seconds must be positive" setup=[TestHelpers] begin
+    import TestItemControllers
+    using TestItemControllers: TestItemController, ControllerCallbacks
+
+    callbacks = ControllerCallbacks(
+        on_testitem_started = (run_id, item_id, test_env_id) -> nothing,
+        on_testitem_passed = (run_id, item_id, test_env_id, duration) -> nothing,
+        on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> nothing,
+        on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> nothing,
+        on_testitem_skipped = (run_id, item_id, test_env_id) -> nothing,
+        on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
+        on_attach_debugger = (run_id, pipe_name) -> nothing,
+    )
+
+    @test_throws ArgumentError TestItemController(callbacks; activation_progress_seconds=0)
+    @test TestItemController(callbacks).activation_progress_seconds ==
+        TestItemControllers.DEFAULT_ACTIVATION_PROGRESS_SECONDS
+end


### PR DESCRIPTION
Activating an environment covers the test process's own precompilation, so it can legitimately run for minutes. Until it answers, the controller says nothing beyond the `Activating` status it posted at the start — so a run that stalls there leaves a log naming neither the stage nor the process that is stuck.

That is exactly what `Julia 1.10 platform` produced on `macos-26` in [run 32299598241](https://github.com/julia-testitems/TestItemControllers.jl/actions/runs/32299598241/job/96218896477). The item normally takes ~80s; the hang dump shows the nested controller parked in `_activate_env!` on a JSON-RPC reply that never came, and the only other trace in the whole job log was the deadline that eventually killed it.

### Change

For as long as the activation request is outstanding, warn every `activation_progress_seconds` — a new `TestItemController` keyword, default 120 — naming the test process, its package, and how long it has been waiting:

```
┌ Warning: Environment activation still pending
│   testprocess_id = "3896f1a8-…"
│   package = "BasicPackage"
└   elapsed_seconds = 240.0
```

The timer is closed in a `finally`, so it never outlives the send, and it runs on the task that was already off the reactor — no FSM or channel coupling. Nothing about the activation itself changes: a slow one is legitimate and is still not interrupted.

### Tests

Two new items in `test_worker_lifecycle.jl`: one end-to-end run with the interval dialled down to 0.05s, asserting the warning is emitted and carries the process id and elapsed time; one for the keyword's validation and default. `TestHelpers.run_testrun` gained an optional `activation_progress_seconds` to make the first possible.

Suite is green locally: 193/193 with `!(:comprehensive_platform in tags)`, plus the four activation-related items run separately.

Independent of #67 and #69, though all three come out of the same failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)