### PR TITLE
Seed Revise's cache source hash with a UInt, so 32 bit runs can revise

### DIFF
--- a/test/test_testserver_precompile.jl
+++ b/test/test_testserver_precompile.jl
@@ -1,0 +1,42 @@
+@testitem "The test process environment precompiles cleanly" begin
+    # `TestItemServer` assembles the vendored packages by hand, and an override that
+    # *redefines* one of their methods rather than adding a more specific one is a method
+    # overwrite — which Julia rejects outright while a package precompiles.
+    #
+    # Nothing else in this suite notices directly: precompilation is warn-only on the path a
+    # test process takes, so the package still loads. What it costs is a full source reload
+    # of the vendored stack in every test process (tens of seconds each) and a precompile
+    # banner on its stderr, which then lands in whatever a test item captures. Those
+    # second-order effects are how it last surfaced, in assertions about process output.
+    # Assert the cache is actually built instead.
+    env_dir = normpath(joinpath(@__DIR__, "..", "testprocess", "environments"))
+    versioned = joinpath(env_dir, "v$(VERSION.major).$(VERSION.minor)")
+    project = isdir(versioned) ? versioned : joinpath(env_dir, "fallback")
+
+    # `Base.compilecache` rather than `Pkg.precompile`: it rebuilds unconditionally, so a
+    # cache some other test item already wrote cannot short-circuit the check, and it reports
+    # a failure as a `Core.PrecompilableError` return value — `Pkg.precompile` reports one as
+    # a `?` in its progress list and still exits 0.
+    code = """
+        result = Base.compilecache(Base.identify_package("TestItemServer"))
+        result isa Tuple || exit(1)
+        """
+    julia = joinpath(Sys.BINDIR, Base.julia_exename())
+    cmd = `$julia --startup-file=no --history-file=no --project=$project -e $code`
+
+    io = IOBuffer()
+    process = run(pipeline(ignorestatus(cmd), stdout=io, stderr=io))
+    output = String(take!(io))
+
+    ok = success(process) &&
+        !occursin("Method overwriting is not permitted", output) &&
+        !occursin("overwritten at", output)
+    if !ok
+        println("── precompiling TestItemServer in $project ──")
+        println(output)
+    end
+
+    @test success(process)
+    @test !occursin("Method overwriting is not permitted", output)
+    @test !occursin("overwritten at", output)
+end

--- a/testprocess/TestItemServer/src/pkg_imports.jl
+++ b/testprocess/TestItemServer/src/pkg_imports.jl
@@ -96,14 +96,17 @@ module Revise
         # `MethodError: no method matching hash(::UInt64, ::UInt64)`, and every test item that
         # loads a package in that process reports the failed callback as its own error.
         #
-        # `packages/` holds git subtrees that are never edited by hand, so the method is
-        # replaced here instead, where this module is assembled. The value only has to identify
-        # a source snapshot within one session, so truncating is fine, and on 64 bit it is the
-        # same value Revise computes. Guarded like the definition it replaces
+        # `packages/` holds git subtrees that are never edited by hand, so the method is added
+        # here instead, where this module is assembled. It is deliberately *more specific* than
+        # the vendored `cache_src_id(inc)` rather than a redefinition of it: redefining is
+        # method overwriting, which Julia rejects outright while this package precompiles. Both
+        # call sites pass a `Base.CacheHeaderIncludes`, so this one wins dispatch. `inc.hash` is
+        # a `UInt32`, so widening it to `UInt` is exact. Guarded like the definition it shadows
         # (https://github.com/JuliaLang/julia/pull/49866); older versions hash `inc.mtime` and
         # are unaffected. Drop this once the fix is in a released Revise.
-        @static if VERSION >= v"1.11.0-DEV.683"
-            cache_src_id(inc) = hash(inc.fsize, inc.hash % UInt)
+        @static if Sys.WORD_SIZE == 32 && VERSION >= v"1.11.0-DEV.683" &&
+                   isdefined(Base, :CacheHeaderIncludes)
+            cache_src_id(inc::Base.CacheHeaderIncludes) = hash(inc.fsize, UInt(inc.hash))
         end
     elseif VERSION >= v"1.6.0"
         using ..OrderedCollections

--- a/testprocess/TestItemServer/src/pkg_imports.jl
+++ b/testprocess/TestItemServer/src/pkg_imports.jl
@@ -90,6 +90,21 @@ module Revise
         using ...LoweredCodeUtils: next_or_nothing!, callee_matches
 
         include("../../../packages/Revise/src/packagedef.jl")
+
+        # Revise seeds the cache source hash with a `UInt64`, while the seed `hash` takes is a
+        # `UInt` — 32 bits wide on a 32 bit platform. Its package callback dies there with
+        # `MethodError: no method matching hash(::UInt64, ::UInt64)`, and every test item that
+        # loads a package in that process reports the failed callback as its own error.
+        #
+        # `packages/` holds git subtrees that are never edited by hand, so the method is
+        # replaced here instead, where this module is assembled. The value only has to identify
+        # a source snapshot within one session, so truncating is fine, and on 64 bit it is the
+        # same value Revise computes. Guarded like the definition it replaces
+        # (https://github.com/JuliaLang/julia/pull/49866); older versions hash `inc.mtime` and
+        # are unaffected. Drop this once the fix is in a released Revise.
+        @static if VERSION >= v"1.11.0-DEV.683"
+            cache_src_id(inc) = hash(inc.fsize, inc.hash % UInt)
+        end
     elseif VERSION >= v"1.6.0"
         using ..OrderedCollections
         using ..LoweredCodeUtils


### PR DESCRIPTION
Revise passes the precompile cache header's content hash to `hash` as a `UInt64`. The seed `hash` takes is a `UInt`, 32 bits wide on a 32 bit platform, so on every `x86` leg Revise's package callback dies:

```
MethodError: no method matching hash(::UInt64, ::UInt64)
  at cache_src_id (packages/Revise/src/pkgs.jl:138)
  at parse_pkg_files → watch_package → …
```

Every test item that loads a package in that process then reports the failed callback as its own error, which is how this surfaces on [JuliaMCP's `rc~x86` legs](https://github.com/julia-vscode/JuliaMCP.jl/actions/runs/32434348591/job/96636442108) in items that have nothing to do with Revise.

**This replaces the first version of this PR, which fixed it by editing `packages/Revise/src/pkgs.jl`.** That was wrong — `packages/` holds git subtrees that are never edited by hand. Re-vendoring is no help either: the bug is upstream's, and the vendored copy is already at 3.16.4, the latest tag, whose `src/pkgs.jl:138` still reads `cache_src_id(inc) = hash(inc.fsize, UInt64(inc.hash))`.

So the method is supplied where `testprocess/TestItemServer/src/pkg_imports.jl` assembles the `Revise` module, right after the vendored `packagedef.jl` is included. It is **added, not redefined**: a definition with the vendored signature is a method overwrite, which Julia rejects outright while a package precompiles, and the second commit here fixes exactly that regression from the first —

```
WARNING: Method definition cache_src_id(Any) in module Revise at packages/Revise/src/pkgs.jl:138
         overwritten at testprocess/TestItemServer/src/pkg_imports.jl:106.
ERROR: Method overwriting is not permitted during Module precompilation.
  24769.9 ms  ? TestItemServer
```

Precompilation is warn-only on the path a test process takes, so `TestItemServer` still loaded — at the cost of reloading the whole vendored stack from source in every test process, and of a precompile banner on its stderr that landed in whatever a test item captured. That is what reddened the 64 bit legs: the assertions that a process's output carries no ANSI escapes, the coverage items whose processes then went unanswered, and the recycling items that timed out on the extra startup.

Both call sites (`Revise/src/loading.jl:118`, `Revise/src/pkgs.jl:192`) pass a `Base.CacheHeaderIncludes`, so a method on that type is strictly more specific and wins dispatch without touching upstream's `cache_src_id(::Any)`. Guarded to 32 bit, where the bug is — on 64 bit the vendored definition already computes the right value, and leaving its dispatch and invalidation exactly as upstream ships them is one less thing to reason about. `inc.hash` is a `UInt32`, so `UInt(inc.hash)` is an exact widening on either word size; `isdefined` covers the internal Base type, whose shape is unchanged from 1.11 through nightly.

The suite had nothing asserting that `TestItemServer`'s cache is actually built — the breakage only surfaced through unrelated assertions about process output — so `test/test_testserver_precompile.jl` precompiles the version-matched test process environment and fails on a `?`. It uses `Base.compilecache` rather than `Pkg.precompile`: that rebuilds unconditionally, so a cache another item already wrote cannot short-circuit it, and it reports failure as a return value instead of exiting 0. Verified to fail on the overwriting form and pass on this one.

Smoke-tested under both `1.12` and `1.12~x86`: the environment precompiles `✓` on both, the two methods coexist with the 32 bit one winning dispatch and computing the same value, and the color-output, coverage and worker-recycling items all pass.

Found while auditing the stack for Julia 1.13 readiness; like #79 this is a word-size bug the rc legs merely made visible. An upstream Revise PR follows, so the override can be dropped at the next re-vendor.

Note for the `x86` legs: they will keep failing "Coverage without coverage roots" after this merges. That failure's stack trace points into `~/.julia/packages/TestItemControllers/…`, i.e. the *registered* TestItemControllers that `juliati` runs the suite on, not the checkout — it is present on `main` today and clears only once a release carrying this fix is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
