### PR TITLE
Declare Logging in the test target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - Unreleased
 
+### Fixed
+
+- `Logging` is now declared in the test target. `test/test_worker_lifecycle.jl` does `using Logging`, so `Pkg.test()` always ended in `ArgumentError: Package Logging not found in current path` — meaning the test item covering the slow-activation warning had never actually run.
+
 ### Added
 
 - A test item timeout is now logged with the evidence for *which* channel failed: how long it has been since the test process last sent a JSON-RPC message, how long since it last produced output, whether the process's own hang watchdog left a diagnostics dump, and — on a JSONRPC that can report it — how far behind the connection's outbound queue is. A test process talks to the controller over two independent channels, and a timeout only ever proves that the *result* never arrived. Output still arriving while the socket has gone quiet means the connection died, not the test; before this the two were indistinguishable without reconstructing the run from its artifacts afterwards.

--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,11 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 JuliaWorkspaces = "e554591c-7f10-434f-9f27-2097f62a04fd"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 julia = "1.12"
 PrecompileTools = "1.3.4"
 
 [targets]
-test = ["JuliaWorkspaces", "Test", "TestItemRunner", "Pkg"]
+test = ["JuliaWorkspaces", "Test", "TestItemRunner", "Pkg", "Logging"]

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -1530,8 +1530,9 @@ end
 
 # The outbound half of a process's JSON-RPC connection, when the JSONRPC in use can report
 # it. That queue is unbounded, so a peer that has stopped reading never makes a send fail —
-# the messages simply accumulate, undelivered. Guarded by `isdefined` because the compat
-# bound still allows a JSONRPC without the accessor.
+# the messages simply accumulate, undelivered. Guarded by `isdefined` rather than assumed:
+# JSONRPC is vendored here, not a dependency with a compat bound, so what decides whether the
+# accessor exists is when `packages/JSONRPC` was last re-vendored.
 function _outbound_backlog(ps::TestProcessState)
     ps.endpoint === nothing && return nothing
     isdefined(JSONRPC, :outbound_backlog) || return nothing


### PR DESCRIPTION
## `Logging` is missing from the test target

`test/test_worker_lifecycle.jl` does `using Logging`, but `Logging` is in neither `[extras]` nor the `test` target, so `Pkg.test()` always ends in:

```
ArgumentError: Package Logging not found in current path
  at test/test_worker_lifecycle.jl:235
```

That is the test item **"A slow environment activation is reported while it is still running"** — which covers the `activation_progress_seconds` warning added in this same unreleased cycle. So that test has never actually run.

Two side effects worth naming:

- Because it is the last thing the suite prints, this error gets re-investigated as a regression during unrelated work. It is the reason the suite cannot be judged by "did `Pkg.test()` error" and has to be diffed against a baseline instead.
- It costs a real test item's worth of coverage on a feature that is otherwise untested.

## A comment correction

The timeout diagnostics from [#77](https://github.com/julia-testitems/TestItemControllers.jl/pull/77) carry a comment I got wrong. It reads:

> Guarded by `isdefined` because the compat bound still allows a JSONRPC without the accessor.

There is no compat bound. TestItemControllers **vendors** JSONRPC (`packages/JSONRPC`, included from `src/TestItemControllers.jl` and `testprocess/TestItemServer/src/pkg_imports.jl`) rather than depending on it, so what actually decides whether `outbound_backlog` exists is when `packages/JSONRPC` was last re-vendored. The guard itself is correct and stays — it costs nothing and tolerates a partially-updated tree.

## Testing

Not run locally — CI covers it, and this branch is based on current `main`, so its run also exercises the JSONRPC 3.0.2 re-vendor.

Two things to be aware of when reading the CI result, neither caused by this PR:

- `main` has been red since before the re-vendor. `test_process_crash.jl:Controlled crash via exit()` failed at `5d596f407` (`ubuntu 1.12.7~x86`, `windows 1.12.7~x64`) and again at `751fa3750` (`ubuntu 1.12.7~x64`, `windows 1.12.7~x86`). Different legs each time, same test — a flaky-test signature that predates both #77 and the re-vendor, and probably deserves its own issue.
- `test_jsonrpc_controller.jl` has a timing-dependent assertion count (measured 65–84 on an unchanged tree), because it loops `for n in started … @test` and how many notifications land inside its sleep window varies. A differing count there is not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
