### PR TITLE
Close the workload's endpoints before their sockets

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -122,12 +122,13 @@ using PrecompileTools: @setup_workload, @compile_workload
                 packageUri = "file:///precompile-workload",
                 packageName = "PrecompileWorkload",
             ))
-        # Close the sockets before the endpoints so the read tasks unblock
-        # (close(endpoint) waits on its read task).
-        close(stream_a)
-        close(stream_b)
+        # Endpoints first, then the sockets: this is the order the controller uses at
+        # runtime, and `close(endpoint)` unblocks its own read task through the endpoint
+        # cancellation token — `PipeEndpoint` reads are cancellation-aware.
         try close(client) catch end
         try close(server) catch end
+        close(stream_a)
+        close(stream_b)
         try wait(server_task) catch end
         close(listener)
     end


### PR DESCRIPTION
## What

The precompile workload closed its two raw sockets before the JSONRPC endpoints layered on them:

```julia
# Close the sockets before the endpoints so the read tasks unblock
# (close(endpoint) waits on its read task).
close(stream_a)
close(stream_b)
try close(client) catch end
try close(server) catch end
```

The stated reason does not hold. `read_transport_layer` has a `Union{Sockets.TCPSocket,Sockets.PipeEndpoint}` method that threads the cancellation token into `readline`/`read`, and `close(endpoint)` cancels `endpoint_cancellation_source` before it waits on the read task. Closing the endpoint first unblocks its own read task.

This flips the order to endpoints-then-sockets, which is what the controller does at runtime, so the workload compiles the shutdown path in the shape it actually runs.

## What this is not

**This is a consistency change, not a fix.** It does not on its own stop the workload leaking the endpoints' write-monitor timers — the leak that makes precompilation of this package fail with:

```
[pid 21172] waiting for IO to finish:
 Handle type        uv_handle_t->data
 timer              00000220ab236130->00000220a6e0de10
 timer              00000220ab2364b0->00000220a6e0de50
```

Measured on a standalone reproduction of this workload's endpoint section, counting leaked timers:

| | sockets closed first (before) | endpoints closed first (this PR) |
|---|---|---|
| current vendored JSONRPC | **2 leak** | **1 leaks** |
| with julia-vscode/JSONRPC.jl#114 | 0 | 0 |

Closing the endpoints first halves the leak but does not remove it: `close(client)` drives the *server's* read task to a clean EOF, which sets `status_closed`, and `Base.close` then returns at its `status == status_closed` guard before releasing the server's timer.

The actual fix is upstream in **julia-vscode/JSONRPC.jl#114**, and reaches this repo through the next `scripts/update_vendored_packages.jl` subtree pull. `packages/JSONRPC/` is deliberately untouched here.

Verified end to end with that fix vendored in: `Pkg.precompile()` completes in ~10s with no "waiting for IO to finish", and a second run is a cached no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
