### PR TITLE
Strip ANSI escapes from controller log records

### DIFF
--- a/src/TestItemControllers.jl
+++ b/src/TestItemControllers.jl
@@ -33,6 +33,7 @@ include("json_protocol.jl")
 include("../shared/testserver_protocol.jl")
 include("../shared/urihelper.jl")
 
+include("ansi.jl")
 include("datatypes.jl")
 include("results.jl")
 using .Results

--- a/src/ansi.jl
+++ b/src/ansi.jl
@@ -1,0 +1,21 @@
+"""
+ANSI escape sequence stripping.
+
+Test processes are launched with `--color=yes`, so everything they write — `Test.jl`'s
+failure summaries, `Pkg` errors, whatever a test item prints — arrives here carrying
+escape sequences. That is deliberate for the sinks that render them (the Test Results
+terminal, the per process log views), but any place that folds that text into a plain
+context instead — the controller's own log records, JUnit XML — has to take them out
+first.
+"""
+
+const _ANSI_CSI = r"\e\[[0-9;:<=>?]*[ -/]*[@-~]"
+const _ANSI_OSC = r"\e\][^\a\e]*(?:\a|\e\\)"
+const _ANSI_OTHER = r"\e[@-Z\\-_]"
+
+function _strip_ansi(s::AbstractString)
+    s = replace(s, _ANSI_OSC => "")
+    s = replace(s, _ANSI_CSI => "")
+    s = replace(s, _ANSI_OTHER => "")
+    return s
+end

--- a/src/junit.jl
+++ b/src/junit.jl
@@ -12,19 +12,6 @@ profiles produces several test cases with the same `classname`/`name` and differ
 `id`s, which is what a matrix build looks like to a JUnit consumer.
 """
 
-# Strip ANSI escape sequences. Test output is full of them (`Test.jl` colours its failure
-# summaries) and they are meaningless — and, in the C1 control range, illegal — in XML.
-const _ANSI_CSI = r"\e\[[0-9;:<=>?]*[ -/]*[@-~]"
-const _ANSI_OSC = r"\e\][^\a\e]*(?:\a|\e\\)"
-const _ANSI_OTHER = r"\e[@-Z\\-_]"
-
-function _strip_ansi(s::AbstractString)
-    s = replace(s, _ANSI_OSC => "")
-    s = replace(s, _ANSI_CSI => "")
-    s = replace(s, _ANSI_OTHER => "")
-    return s
-end
-
 # XML 1.0 permits tab, newline, carriage return and everything from U+0020 up (minus the
 # surrogates). Anything else has no representation at all — not even as a character
 # reference — so it is dropped rather than escaped.

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -1802,7 +1802,7 @@ function handle!(c::TestItemController, msg::ActivationFailedMsg)
         error("Received ActivationFailedMsg for process '$(msg.testprocess_id)' in unexpected state '$(state(ps.fsm))'")
     end
 
-    @warn "Environment activation failed for process" testprocess_id=msg.testprocess_id is_precompile=ps.is_precompile_process error=msg.error_message
+    @warn "Environment activation failed for process" testprocess_id=msg.testprocess_id is_precompile=ps.is_precompile_process error=_strip_ansi(msg.error_message)
 
     if ps.testrun_id === nothing || !haskey(c.test_runs, ps.testrun_id)
         error("Received ActivationFailedMsg for process '$(msg.testprocess_id)' with unknown or missing testrun ID '$(ps.testrun_id)'")

--- a/src/testprocess.jl
+++ b/src/testprocess.jl
@@ -61,7 +61,13 @@ function _convert_perf_stats(perf::Union{Missing,TestItemServerProtocol.PerfStat
     )
 end
 
+# Prepare test process output for embedding in one of our own log records. The child runs
+# with `--color=yes`, so its output is full of ANSI escapes; our log goes to a plain
+# `ConsoleLogger` on stderr, which the extension appends verbatim to an output channel that
+# renders none of them. Stripping before the size check also keeps escape bytes out of the
+# budget, and stops truncation from severing a sequence part way through.
 function _truncate_for_log(s::AbstractString; max_bytes::Int=8192)
+    s = _strip_ansi(s)
     if ncodeunits(s) <= max_bytes
         return s
     end
@@ -484,7 +490,7 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
                     # The only record of why a process died before it could connect. It is
                     # dropped on the floor below, where all that survives is an exit code,
                     # so surface it here while we still have it.
-                    @warn "Test process crashed during startup" testprocess_id exitcode=err.exitcode termsignal=err.termsignal output=err.captured_output
+                    @warn "Test process crashed during startup" testprocess_id exitcode=err.exitcode termsignal=err.termsignal output=_strip_ansi(err.captured_output)
                 end
 
                 if !(err isa CancellationTokens.OperationCanceledException)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -50,3 +50,29 @@ end
     @test _exit_info_string(nothing, 0) === nothing
     @test _exit_info_string(nothing, nothing) === nothing
 end
+
+@testitem "_truncate_for_log strips ANSI escapes" begin
+    using TestItemControllers: _truncate_for_log
+
+    # Test processes run with `--color=yes`, so anything we fold into our own log records
+    # arrives coloured; the controller log is a plain output channel that renders none of it.
+    @test _truncate_for_log("\e[31mred\e[0m") == "red"
+    @test _truncate_for_log("\e[1;32mbold green\e[0m — καλά 🎉") == "bold green — καλά 🎉"
+    @test _truncate_for_log("\e]0;a title\acleared\e[2K") == "cleared"
+    @test _truncate_for_log("plain text") == "plain text"
+end
+
+@testitem "_truncate_for_log truncates on a character boundary" begin
+    using TestItemControllers: _truncate_for_log
+
+    s = repeat("α", 100)  # 200 bytes
+    r = _truncate_for_log(s; max_bytes=51)
+    @test isvalid(r)
+    @test startswith(r, repeat("α", 25))
+    @test occursin("bytes truncated", r)
+
+    # Escapes are removed before the budget applies, so they cannot eat into it or be
+    # severed part way through.
+    @test _truncate_for_log("\e[31m" * repeat("a", 10) * "\e[0m"; max_bytes=20) ==
+        repeat("a", 10)
+end


### PR DESCRIPTION
## Problem

The "Julia Test Item Controller" output channel in VS Code shows raw ANSI control sequences.

The initial suspicion was that we had turned on color for the controller process itself. We had not — the controller is spawned without `--color=yes`, nothing sets `FORCE_COLOR`/`NO_COLOR`, and Julia's `ConsoleLogger(stderr)` emits no escapes when stderr is a pipe.

The escapes come from **test process** output. Those *are* launched with `--color=yes` (deliberately, so anything a test item prints can carry color), and three places fold that borrowed text into the controller's *own* log records as key/value payloads. Those records go to a plain `ConsoleLogger` on stderr, which the extension appends verbatim to a `vscode.OutputChannel` — not terminal backed, so the escapes render literally.

## Fix

Color for test processes is correct and is unchanged; only the borrowed child output is sanitised.

`_strip_ansi` already existed in `junit.jl`. Moved it and its regexes verbatim into a new `ansi.jl` — `testprocess.jl` should not have to depend on the JUnit XML writer for it — and applied it at the three sites:

- **`_truncate_for_log`** — covers both `@debug` output-forwarding records. Stripping *before* the size check also fixes a latent bug: escape bytes no longer eat into the 8192-byte budget, and truncation can no longer sever a sequence part way through.
- **`Test process crashed during startup`** warning — fires in normal operation, not only under `JULIA_DEBUG=TestItemControllers`.
- **`Environment activation failed for process`** warning — its message originates in the color-enabled child (Pkg errors are colorized).

`TestProcessOutputMsg`/`AppendOutputMsg` payloads are left untouched: those flow to the Test Results terminal and the per-process log views, which render ANSI on purpose.

## Testing

Full suite green (214/214), including the existing JUnit tests that exercise the moved `_strip_ansi`. Added two testitems in `test/test_utils.jl` covering the stripping and the character-boundary truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)