### PR TITLE
Bound environment activation with an optional timeout, and say when it ends

### DIFF
--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -37,6 +37,12 @@ the reactor event loop, then use [`execute_testrun`](@ref) to submit work.
   is reported with a warning (default 120). Activation covers the test process's own
   precompilation, so a slow one is normal and is not interrupted; this only makes it visible
   while it is happening instead of only in the post-mortem of whatever kills the run.
+- `activation_timeout_seconds::Union{Nothing,Real}` — how long an environment activation may
+  take before it is abandoned and reported as a failure, or `nothing` (the default) for no
+  limit. Off by default for the same reason the per-test-item timeout is: a legitimate
+  activation is a precompilation, and no one number fits every project. Set it where a stalled
+  activation would otherwise burn a whole CI job, which nothing else covers — the per-item
+  timeout cannot fire, because no item has started.
 
 # Lifecycle
 
@@ -86,6 +92,10 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
     # finished.
     activation_progress_seconds::Float64
 
+    # How long `_activate_env!` waits for an activation before giving up on it, or `nothing`
+    # for no limit — the default, matching the per-test-item timeout.
+    activation_timeout_seconds::Union{Nothing,Float64}
+
     # Scheduling history, in memory and keyed by the (stable) test item id. It survives
     # across the test runs of one session; nothing is persisted to disk.
     schedule::Symbol
@@ -100,7 +110,8 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
         log_level::Symbol=:Info,
         schedule::Symbol=:duration,
         shutdown_grace_seconds::Real=DEFAULT_SHUTDOWN_GRACE_SECONDS,
-        activation_progress_seconds::Real=DEFAULT_ACTIVATION_PROGRESS_SECONDS) where {CB<:ControllerCallbacks}
+        activation_progress_seconds::Real=DEFAULT_ACTIVATION_PROGRESS_SECONDS,
+        activation_timeout_seconds::Union{Nothing,Real}=nothing) where {CB<:ControllerCallbacks}
 
         schedule in (:duration, :contiguous) ||
             throw(ArgumentError("schedule must be :duration or :contiguous, got $(repr(schedule))"))
@@ -108,6 +119,8 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
             throw(ArgumentError("shutdown_grace_seconds must be positive, got $(shutdown_grace_seconds)"))
         activation_progress_seconds > 0 ||
             throw(ArgumentError("activation_progress_seconds must be positive, got $(activation_progress_seconds)"))
+        activation_timeout_seconds === nothing || activation_timeout_seconds > 0 ||
+            throw(ArgumentError("activation_timeout_seconds must be positive or nothing, got $(activation_timeout_seconds)"))
 
         return new{CB}(
             callbacks,
@@ -125,6 +138,7 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
             Float64(shutdown_grace_seconds),
             nothing,
             Float64(activation_progress_seconds),
+            activation_timeout_seconds === nothing ? nothing : Float64(activation_timeout_seconds),
             schedule,
             Dict{String,Symbol}(),
             Dict{String,Float64}(),
@@ -2355,9 +2369,21 @@ function _activate_env!(c::TestItemController, ps::TestProcessState)
         # that names neither the stage nor the process.
         interval = c.activation_progress_seconds
         started = time()
+        # Whether the activation was ever reported as outstanding. If it was, its landing is
+        # worth a line of its own: a log that says "still pending" three times and then goes
+        # quiet reads the same whether the activation finished or the job did.
+        reported_pending = Ref(false)
         progress_timer = Timer(interval, interval=interval) do _
-            @warn "Environment activation still pending" testprocess_id=ps.id package=ps.env.package_name elapsed_seconds=round(time() - started, digits=1)
+            reported_pending[] = true
+            @warn "Environment activation still pending" testprocess_id=ps.id package=ps.env.package_name is_precompile=ps.is_precompile_process elapsed_seconds=round(time() - started, digits=1)
         end
+        # `nothing` — the default — means an activation is allowed to take as long as it
+        # takes, which is the only honest default when it covers a precompilation. Where one
+        # is set, it is the sole guard on this stage: the per-test-item timeout cannot fire
+        # here, because no item has started.
+        deadline_cs = c.activation_timeout_seconds === nothing ? nothing :
+            CancellationTokens.CancellationTokenSource(c.activation_timeout_seconds)
+        deadline_token = deadline_cs === nothing ? nothing : CancellationTokens.get_token(deadline_cs)
         result = try
             JSONRPC.send(
                 ps.endpoint,
@@ -2366,16 +2392,37 @@ function _activate_env!(c::TestItemController, ps::TestProcessState)
                     projectUri = something(ps.env.project_uri, missing),
                     packageUri = ps.env.package_uri,
                     packageName = ps.env.package_name
-                )
+                );
+                client_token = deadline_token
             )
+        catch err
+            # Only the deadline is handled here. Every other cancellation — the endpoint
+            # going away, the run being cancelled — belongs to the outer handler, which
+            # already tells those apart.
+            if err isa CancellationTokens.OperationCanceledException &&
+                    deadline_token !== nothing &&
+                    CancellationTokens.is_cancellation_requested(deadline_token)
+                elapsed = round(time() - started, digits=1)
+                @warn "Environment activation timed out" testprocess_id=ps.id package=ps.env.package_name is_precompile=ps.is_precompile_process elapsed_seconds=elapsed timeout_seconds=c.activation_timeout_seconds
+                put!(c.reactor_channel, ActivationFailedMsg(
+                    ps.id,
+                    "Environment activation timed out after $(c.activation_timeout_seconds) seconds"))
+                return
+            end
+            rethrow()
         finally
             close(progress_timer)
+            deadline_cs === nothing || close(deadline_cs)
         end
 
         if result.status == "failed"
             @warn "Environment activation failed" testprocess_id=ps.id error=coalesce(result.error, "unknown error")
             put!(c.reactor_channel, ActivationFailedMsg(ps.id, coalesce(result.error, "Environment activation failed")))
             return
+        end
+
+        if reported_pending[]
+            @warn "Environment activation completed" testprocess_id=ps.id package=ps.env.package_name is_precompile=ps.is_precompile_process elapsed_seconds=round(time() - started, digits=1)
         end
 
         if ps.is_precompile_process && ps.testrun_id !== nothing

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -373,7 +373,7 @@
     # the second run gets the pooled, already-warm test process of the first. `runs` in the
     # returned value holds the per-run events and output; `events`/`outputs` are the union
     # across runs, which is what a single-run caller wants.
-    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false, activation_progress_seconds=nothing)
+    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false, activation_progress_seconds=nothing, activation_timeout_seconds=nothing)
         events = NamedTuple[]
         events_lock = ReentrantLock()
         push_event!(e) = lock(events_lock) do
@@ -427,8 +427,8 @@
         end
 
         controller = activation_progress_seconds === nothing ?
-            TestItemController(callbacks; log_level=log_level) :
-            TestItemController(callbacks; log_level=log_level, activation_progress_seconds=activation_progress_seconds)
+            TestItemController(callbacks; log_level=log_level, activation_timeout_seconds=activation_timeout_seconds) :
+            TestItemController(callbacks; log_level=log_level, activation_progress_seconds=activation_progress_seconds, activation_timeout_seconds=activation_timeout_seconds)
         test_env = make_test_environment(; mode=mode, julia_cmd=julia_cmd, julia_args=julia_args, env=env, package_name=package_name, package_uri=package_uri, project_uri=project_uri, env_content_hash=env_content_hash, color=color)
 
         # Build work units from items

--- a/test/test_worker_lifecycle.jl
+++ b/test/test_worker_lifecycle.jl
@@ -251,6 +251,68 @@ end
     # It names what is slow, not just that something is.
     @test haskey(first(pending).kwargs, :testprocess_id)
     @test first(pending).kwargs[:elapsed_seconds] > 0
+
+    # And it says when the wait ended. Without this the log is ambiguous between an
+    # activation that finished and a job that was killed while it was still pending; with
+    # several processes outstanding, the shared `testprocess_id` is what pairs them up.
+    completed = filter(r -> r.message == "Environment activation completed", logger.logs)
+    @test !isempty(completed)
+    @test first(completed).kwargs[:testprocess_id] == first(pending).kwargs[:testprocess_id]
+    @test first(completed).kwargs[:elapsed_seconds] >= first(pending).kwargs[:elapsed_seconds]
+end
+
+@testitem "A fast environment activation is not reported at all" setup=[TestHelpers] begin
+    # The completion line is bound to the pending one: an activation nobody was told to wait
+    # for has nothing to report. Otherwise every run would gain a line per process for a
+    # non-event.
+    using Logging: with_logger, Warn
+    using Test: TestLogger
+
+    discovered = TestHelpers.basic_package_discovery()
+    items = filter(i -> i.label == "add works", discovered.items)
+
+    logger = TestLogger(min_level=Warn)
+    result = with_logger(logger) do
+        TestHelpers.run_testrun(items, discovered.setups, discovered)
+    end
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 1
+    @test isempty(filter(r -> r.message == "Environment activation completed", logger.logs))
+end
+
+@testitem "An environment activation that outlives its timeout errors its items" setup=[TestHelpers] begin
+    # The activation timeout is the only guard on this stage: the per-test-item timeout
+    # cannot fire before an item has started, so without this a wedged activation runs until
+    # something outside the controller kills the job. A CI run burned five hours that way.
+    #
+    # The timeout is dialled down far below what a real activation needs, so a *normal* one
+    # trips it — the same trick the progress test uses on its interval.
+    using Logging: with_logger, Warn
+    using Test: TestLogger
+
+    discovered = TestHelpers.basic_package_discovery()
+    items = filter(i -> i.label == "add works", discovered.items)
+    @test length(items) == 1
+
+    logger = TestLogger(min_level=Warn)
+    result = with_logger(logger) do
+        TestHelpers.run_testrun(items, discovered.setups, discovered; activation_timeout_seconds=0.05)
+    end
+
+    # It fails the run rather than hanging it, through the same path a genuinely broken
+    # environment takes.
+    errored = filter(e -> e.event == :errored, result.events)
+    @test length(errored) == length(items)
+    @test isempty(filter(e -> e.event == :passed, result.events))
+    @test occursin("timed out", first(errored).messages[1].message)
+
+    timed_out = filter(r -> r.message == "Environment activation timed out", logger.logs)
+    @test !isempty(timed_out)
+    @test haskey(first(timed_out).kwargs, :testprocess_id)
+    @test first(timed_out).kwargs[:timeout_seconds] == 0.05
+
+    # The process is torn down, not left behind holding the env.
+    @test !isempty(filter(e -> e.event == :process_terminated, result.process_events))
 end
 
 @testitem "activation_progress_seconds must be positive" setup=[TestHelpers] begin
@@ -270,4 +332,26 @@ end
     @test_throws ArgumentError TestItemController(callbacks; activation_progress_seconds=0)
     @test TestItemController(callbacks).activation_progress_seconds ==
         TestItemControllers.DEFAULT_ACTIVATION_PROGRESS_SECONDS
+end
+
+@testitem "activation_timeout_seconds is off by default and must be positive" setup=[TestHelpers] begin
+    import TestItemControllers
+    using TestItemControllers: TestItemController, ControllerCallbacks
+
+    callbacks = ControllerCallbacks(
+        on_testitem_started = (run_id, item_id, test_env_id) -> nothing,
+        on_testitem_passed = (run_id, item_id, test_env_id, duration) -> nothing,
+        on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> nothing,
+        on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> nothing,
+        on_testitem_skipped = (run_id, item_id, test_env_id) -> nothing,
+        on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
+        on_attach_debugger = (run_id, pipe_name) -> nothing,
+    )
+
+    # Off by default, like the per-test-item timeout: a legitimate activation is a
+    # precompilation, and no one number fits every project.
+    @test TestItemController(callbacks).activation_timeout_seconds === nothing
+    @test TestItemController(callbacks; activation_timeout_seconds=30).activation_timeout_seconds == 30.0
+    @test_throws ArgumentError TestItemController(callbacks; activation_timeout_seconds=0)
+    @test_throws ArgumentError TestItemController(callbacks; activation_timeout_seconds=-1)
 end


### PR DESCRIPTION
Environment activation is the one stage of a run that nothing guards. It covers the test process's own precompilation, so a slow one is legitimate and the controller deliberately does not interrupt it — but a *stalled* one has no deadline at all, and the per-test-item timeout cannot stand in, because no item has started.

That gap is not hypothetical. Runs [32515865384](https://github.com/julia-testitems/TestItemControllers.jl/actions/runs/32515865384) and [32515857290](https://github.com/julia-testitems/TestItemControllers.jl/actions/runs/32515857290) each sat in activation in **every** job for 300+ minutes, logging nothing but `Environment activation still pending … elapsed_seconds = 18001.0`, until the runner killed them. (Root cause not chased here — the leading suspect, the vendored JSONRPC 3.0.2 write-monitor shutdown path, is already superseded on `main` by JSONRPC 3.0.3 and #82.)

## What this adds

**`activation_timeout_seconds`, default `nothing`.** Off by default for the same reason the per-test-item timeout is: a legitimate activation is a precompilation, and no one number fits every project. Where it is set, the deadline rides on the request as a `client_token` — the typed `JSONRPC.send` already forwards one — and the expiry is routed into `ActivationFailedMsg`, the path a genuinely broken environment already takes. So the process is torn down and its items errored with a message that says what happened, rather than a new failure mode being invented.

**A completion line.** A log that says `still pending` three times and then goes quiet reads the same whether the activation landed or the job was killed under it. So `Environment activation completed` is emitted — but only when a pending line was, since an activation nobody was told to wait for is not news. A fast run stays exactly as quiet as it is today.

**`is_precompile` on both records**, alongside the `testprocess_id` they already carried. That id is what pairs a completion with its pending lines when several activations are outstanding.

## Note on the log flood

The `still pending` warnings that prompted this are, in the ordinary case, **new reporting rather than a new stall**: the warning landed in #70 on 08-19 and only reached CI when `julia-run-testitems` bumped to 1.7.0/1.8.0 on 08-20. At 120s it fires 2-3× per job for a 4-7 minute precompile that has always taken that long — job durations across 08-19 → 08-22 are unchanged. Nothing here changes that cadence; the `check-bounds` default flip in `julia-actions/julia-run-testitems` is what should shorten those activations.

## Tests

`test/test_worker_lifecycle.jl`, following the existing slow-activation test:

- the slow-activation test now also asserts the completion record and that it shares the pending record's `testprocess_id`;
- a fast activation emits neither;
- an activation given a 0.05s budget errors its items through the `ActivationFailedMsg` path, logs `Environment activation timed out`, and terminates its process;
- `activation_timeout_seconds` is `nothing` by default and rejects non-positive values.

All 7 activation-related items pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
