### PR TITLE
Assert which item a crash is blamed on, and say what happened when it is wrong

### DIFF
--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -523,5 +523,55 @@
         return (events=events, process_events=process_events, coverage=coverage_result, outputs=outputs, process_output=process_output, runs=runs)
     end
 
+    """
+        dump_run(label, result; items=nothing, tail=4000)
+
+    Print everything the controller reported about a `run_testrun` result, as one `@error`.
+
+    Call this immediately before an assertion that has just been decided the wrong way. What
+    an event stream fails to contain is not something the assertion can show — a
+    `length(passed) == 1 / Evaluated: 0 == 1` on CI says an item did not pass and nothing
+    about what happened to it instead. The messages on the *other* events, and the test
+    processes' own output, are where that lives.
+
+    Pass `items` (any collection of `TestItemDetail`) to have ids rendered as labels.
+    """
+    function dump_run(label::AbstractString, result; items=nothing, tail::Int=4000)
+        names = Dict{String,String}()
+        if items !== nothing
+            for i in items
+                names[i.id] = i.label
+            end
+        end
+        name_of(id) = id === nothing ? "-" : get(names, id, id)
+
+        io = IOBuffer()
+        println(io, "── test item events ──")
+        for e in result.events
+            print(io, "  ", rpad(String(e.event), 9), " ", name_of(get(e, :testitem_id, nothing)))
+            for m in something(get(e, :messages, nothing), ())
+                print(io, "
+              ", _clip(m.message, tail))
+            end
+            println(io)
+        end
+
+        println(io, "── process events ──")
+        for e in result.process_events
+            println(io, "  ", rpad(String(e.event), 18), " ", e.id, haskey(e, :status) ? "  $(e.status)" : "")
+        end
+
+        println(io, "── test process output ──")
+        for (pid, chunks) in result.process_output
+            println(io, "  [", pid, "]")
+            println(io, _clip(join(chunks), tail))
+        end
+
+        @error "$(label): run diagnostics
+$(String(take!(io)))"
+    end
+
+    _clip(s::AbstractString, n::Int) = length(s) <= n ? s : "…" * s[prevind(s, lastindex(s), n - 1):end]
+
     import UUIDs
 end

--- a/test/test_process_crash.jl
+++ b/test/test_process_crash.jl
@@ -1,106 +1,49 @@
 @testitem "Controlled crash via exit()" setup=[TestHelpers] begin
-    using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown, ControllerCallbacks
-    import UUIDs
-    @info "[test] Controlled crash via exit(): starting"
-
     pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
     discovered = TestHelpers.discover_test_items(pkg_path)
 
-    # Get the exit-crashing item and a passing item
     crash_items = filter(i -> i.label == "exit crash", discovered.items)
     passing_items = filter(i -> i.label == "add works", discovered.items)
     @test length(crash_items) == 1
     @test length(passing_items) == 1
 
-    all_items = vcat(crash_items, passing_items)
+    # One process for both items, so the crash always lands on a process that still owes a
+    # result for the other one.
+    result = TestHelpers.run_testrun(vcat(crash_items, passing_items), discovered.setups, discovered; max_procs=1, timeout=600)
 
-    events = NamedTuple[]
-    events_lock = ReentrantLock()
-    process_events = NamedTuple[]
-    process_events_lock = ReentrantLock()
-
-    callbacks = ControllerCallbacks(
-        on_testitem_started = (run_id, item_id, test_env_id) -> lock(events_lock) do
-            push!(events, (event=:started, testitem_id=item_id))
-        end,
-        on_testitem_passed = (run_id, item_id, test_env_id, duration) -> lock(events_lock) do
-            push!(events, (event=:passed, testitem_id=item_id))
-        end,
-        on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> lock(events_lock) do
-            push!(events, (event=:failed, testitem_id=item_id, messages=messages))
-        end,
-        on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> lock(events_lock) do
-            push!(events, (event=:errored, testitem_id=item_id, messages=messages))
-        end,
-        on_testitem_skipped = (run_id, item_id, test_env_id) -> lock(events_lock) do
-            push!(events, (event=:skipped, testitem_id=item_id))
-        end,
-        on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
-        on_attach_debugger = (run_id, pipe_name) -> nothing,
-        on_process_created = (id, test_env_id) -> lock(process_events_lock) do
-            push!(process_events, (event=:process_created, id=id))
-        end,
-        on_process_terminated = id -> lock(process_events_lock) do
-            push!(process_events, (event=:process_terminated, id=id))
-        end,
-        on_process_status_changed = (id, status) -> nothing,
-        on_process_output = (id, output) -> nothing,
-    )
-
-    controller = TestItemController(callbacks; log_level=:Debug)
-    test_env = TestHelpers.make_test_environment(; TestHelpers._env_kwargs(discovered)...)
-    testrun_id = string(UUIDs.uuid4())
-    work_units = [TestRunItem(item.id, test_env.id, nothing, :Debug) for item in all_items]
-
-    controller_task = @async try
-        run(controller)
-    catch err
-        @error "Controller error" exception=(err, catch_backtrace())
-    end
-
-    @info "[test] Controlled crash via exit(): executing testrun"
-    testrun_task = @async try
-        execute_testrun(controller, testrun_id, [test_env], all_items, work_units, discovered.setups, 1, nothing)
-    catch err
-        @error "Test run error" exception=(err, catch_backtrace())
-    end
-
-    # The testrun should complete naturally: crash item errored, passing item redistributed and passed.
-    TestHelpers.timed_wait(testrun_task, 600; label="exit-crash-testrun")
-
-    @info "[test] Controlled crash via exit(): shutting down"
-    shutdown(controller)
-    TestHelpers.timed_wait(controller_task, 600; label="exit-crash-controller")
-
-    @info "[test] Controlled crash via exit(): verifying results"
-
-    # The crashing item should be errored with a crash message
     crash_id = crash_items[1].id
-    crash_errored = lock(events_lock) do
-        filter(e -> e.testitem_id == crash_id && e.event == :errored, events)
-    end
-    @test length(crash_errored) == 1
-    @test any(m -> occursin("crashed", m.message), crash_errored[1].messages)
-
-    # The passing item should have passed (redistributed to a replacement process)
     pass_id = passing_items[1].id
-    pass_passed = lock(events_lock) do
-        filter(e -> e.testitem_id == pass_id && e.event == :passed, events)
-    end
-    @test length(pass_passed) == 1
+    terminal(id) = filter(e -> e.testitem_id == id && e.event in (:passed, :failed, :errored, :skipped), result.events)
+    crash_terminal = terminal(crash_id)
+    pass_terminal = terminal(pass_id)
+
+    # Which item the crash is blamed on is the whole point of this item, and it turns on the
+    # controller having actually read every result the process sent before it exited. A
+    # result already on the wire but not yet consumed used to be discarded at the disconnect,
+    # leaving `add works` on record as still-running: it was reported as the crashed item and
+    # `exit crash`, which is the one that really called `exit()`, was redistributed to a
+    # replacement instead. Assert both attributions, not just a count of passes — a bare
+    # `Evaluated: 0 == 1` says nothing about what the item became instead.
+    attributed_correctly = length(crash_terminal) == 1 && crash_terminal[1].event === :errored &&
+        length(pass_terminal) == 1 && pass_terminal[1].event === :passed
+    attributed_correctly || TestHelpers.dump_run("Controlled crash via exit()", result; items=discovered.items)
+
+    @test length(crash_terminal) == 1
+    @test !isempty(crash_terminal) && crash_terminal[1].event === :errored
+    @test !isempty(crash_terminal) && crash_terminal[1].event === :errored &&
+        any(m -> occursin("crashed", m.message), crash_terminal[1].messages)
+
+    @test length(pass_terminal) == 1
+    @test !isempty(pass_terminal) && pass_terminal[1].event === :passed
 
     # A replacement process may or may not be created depending on item execution order.
     # If the crash item ran first, the passing item needs a replacement process.
     # If the passing item ran first, it already completed and no replacement is needed.
-    created = lock(process_events_lock) do
-        filter(e -> e.event == :process_created, process_events)
-    end
+    created = filter(e -> e.event == :process_created, result.process_events)
     @test length(created) >= 1
 
     # At least one process should have been terminated (the crashed one)
-    terminated = lock(process_events_lock) do
-        filter(e -> e.event == :process_terminated, process_events)
-    end
+    terminated = filter(e -> e.event == :process_terminated, result.process_events)
     @test length(terminated) >= 1
 end
 
@@ -218,10 +161,6 @@ end
 end
 
 @testitem "Single crash item is immediately errored" setup=[TestHelpers] begin
-    using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown, ControllerCallbacks
-    import UUIDs
-    @info "[test] Single crash item is immediately errored: starting"
-
     pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
     discovered = TestHelpers.discover_test_items(pkg_path)
 
@@ -229,83 +168,22 @@ end
     crash_items = filter(i -> i.label == "exit crash", discovered.items)
     @test length(crash_items) == 1
 
-    events = NamedTuple[]
-    events_lock = ReentrantLock()
-    process_events = NamedTuple[]
-    process_events_lock = ReentrantLock()
+    result = TestHelpers.run_testrun(crash_items, discovered.setups, discovered; max_procs=1, timeout=600)
 
-    callbacks = ControllerCallbacks(
-        on_testitem_started = (run_id, item_id, test_env_id) -> lock(events_lock) do
-            push!(events, (event=:started, testitem_id=item_id))
-        end,
-        on_testitem_passed = (run_id, item_id, test_env_id, duration) -> lock(events_lock) do
-            push!(events, (event=:passed, testitem_id=item_id))
-        end,
-        on_testitem_failed = (run_id, item_id, test_env_id, messages, duration) -> lock(events_lock) do
-            push!(events, (event=:failed, testitem_id=item_id, messages=messages))
-        end,
-        on_testitem_errored = (run_id, item_id, test_env_id, messages, duration) -> lock(events_lock) do
-            push!(events, (event=:errored, testitem_id=item_id, messages=messages))
-        end,
-        on_testitem_skipped = (run_id, item_id, test_env_id) -> lock(events_lock) do
-            push!(events, (event=:skipped, testitem_id=item_id))
-        end,
-        on_append_output = (run_id, item_id, test_env_id, output) -> nothing,
-        on_attach_debugger = (run_id, pipe_name) -> nothing,
-        on_process_created = (id, test_env_id) -> lock(process_events_lock) do
-            push!(process_events, (event=:process_created, id=id))
-        end,
-        on_process_terminated = id -> lock(process_events_lock) do
-            push!(process_events, (event=:process_terminated, id=id))
-        end,
-        on_process_status_changed = (id, status) -> nothing,
-        on_process_output = (id, output) -> nothing,
-    )
-
-    controller = TestItemController(callbacks; log_level=:Debug)
-    test_env = TestHelpers.make_test_environment(; TestHelpers._env_kwargs(discovered)...)
-    testrun_id = string(UUIDs.uuid4())
-    work_units = [TestRunItem(item.id, test_env.id, nothing, :Debug) for item in crash_items]
-
-    controller_task = @async try
-        run(controller)
-    catch err
-        @error "Controller error" exception=(err, catch_backtrace())
-    end
-
-    @info "[test] Single crash item: executing testrun"
-    testrun_task = @async try
-        execute_testrun(controller, testrun_id, [test_env], crash_items, work_units, discovered.setups, 1, nothing)
-    catch err
-        @error "Test run error" exception=(err, catch_backtrace())
-    end
-
-    # Testrun completes naturally — the crash item is immediately errored, no other items remain.
-    TestHelpers.timed_wait(testrun_task, 600; label="single-crash-testrun")
-
-    @info "[test] Single crash item: shutting down"
-    shutdown(controller)
-    TestHelpers.timed_wait(controller_task, 600; label="single-crash-controller")
-
-    @info "[test] Single crash item: verifying results"
-
-    # The crash item should be errored with a crash message
     crash_id = crash_items[1].id
-    crash_errored = lock(events_lock) do
-        filter(e -> e.testitem_id == crash_id && e.event == :errored, events)
-    end
+    crash_errored = filter(e -> e.testitem_id == crash_id && e.event == :errored, result.events)
+    created = filter(e -> e.event == :process_created, result.process_events)
+    terminated = filter(e -> e.event == :process_terminated, result.process_events)
+
+    length(crash_errored) == 1 && length(created) == 1 && length(terminated) == 1 ||
+        TestHelpers.dump_run("Single crash item is immediately errored", result; items=discovered.items)
+
     @test length(crash_errored) == 1
-    @test any(m -> occursin("crashed", m.message), crash_errored[1].messages)
+    @test !isempty(crash_errored) && any(m -> occursin("crashed", m.message), crash_errored[1].messages)
 
     # Only 1 process should have been created (no replacement needed)
-    created = lock(process_events_lock) do
-        filter(e -> e.event == :process_created, process_events)
-    end
     @test length(created) == 1
 
     # The crashed process should have been terminated
-    terminated = lock(process_events_lock) do
-        filter(e -> e.event == :process_terminated, process_events)
-    end
     @test length(terminated) == 1
 end


### PR DESCRIPTION
Tests and diagnostics only — no `src/` change, and no re-vendor of `packages/JSONRPC`.

## Why

`Controlled crash via exit()` has been the one red item on `ubuntu rc~x86` (and `beta~x86`) for days, and all it ever reported was:

```
Expression: length(pass_passed) == 1
 Evaluated: 0 == 1
```

The trivial `add works` item did not pass. What it became *instead* — the thing that explains the failure — was in none of it: not the assertion, not the events the item recorded, not the output it kept, because these three crash items build their own controller callbacks with `on_append_output` and `on_process_output` wired to `nothing`. The only reason it was diagnosable at all is that an unrelated item in `test_coverage.jl` happens to route through `TestHelpers.run_testrun`, which does keep that evidence.

## What changed

* The two "run it and wait" crash items now go through `TestHelpers.run_testrun`, which already records item events with their messages, process status changes, and each test process's own output. That also drops ~120 lines of hand-rolled callbacks per item. `Hard crash via ccall abort` keeps its own controller — it polls for the crash and force-shuts-down on Windows, which `run_testrun` does not model.
* New `TestHelpers.dump_run` prints all of that as one `@error` block, ids rendered as labels. Both items call it just before an assertion that has already been decided the wrong way.
* The assertions now check the **attribution**, not a count of passes: the passing item must have exactly one terminal event and it must be `:passed`; the crashing item exactly one, and `:errored`.

## The bug this exposes

From the `ubuntu rc~x86` results artifact of run 32555832908:

```
Test process '6a93…' crashed (exit code 0) while running test item 'add works', erroring it immediately
Redistributing 1 un-started item(s) from crashed process '6a93…'
```

`add works` had already passed, and `exit crash` is the item that calls `exit()`. The two were swapped. The cause is in vendored JSONRPC: `in_msg_queue` is unbounded, so the read task runs ahead of the consumer, and a peer disconnect cancelled the endpoint token and closed the queue in one go — discarding every result already sent but not yet read. The controller was left holding `add works` as still-running and blamed the crash on it. Fixed in julia-vscode/JSONRPC.jl#116.

Since this PR carries no re-vendor, the `rc~x86` leg is expected to stay red here — but with a failure that names the mechanism instead of `0 == 1`.

## Verification

Full suite 219/219 green locally on 1.12.7 x64. The `dump_run` path was exercised by temporarily forcing it; it renders the event stream (`started add works` / `passed add works` / `started exit crash` / `errored exit crash` + message), the process events, and both test processes' output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)