### PR TITLE
Stop a run on the reactor, so a stop request cannot lose to queued work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestItemControllers"
 uuid = "340407ab-12a4-4a78-8da2-3de3b3fd1448"
 authors = ["David Anthoff <anthoff@berkeley.edu>"]
-version = "1.9.1-DEV"
+version = "1.10.0-DEV"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/state.jl
+++ b/src/state.jl
@@ -128,6 +128,12 @@ mutable struct TestRunState
     # (default: on whenever the run uses more than one process).
     gc_between_testitems::Bool
     memory_threshold::Union{Nothing,Float64}
+    # Stop the run at the first failing or errored work unit. Decided on the reactor rather
+    # than by a consumer reacting to a callback: items are handed to a worker as a batch, so
+    # by the time a consumer-issued cancellation reaches the reactor channel the next result
+    # may already be queued ahead of it and would be recorded as a second failure.
+    failfast::Bool
+    failure_seen::Bool
 end
 
 """
@@ -192,6 +198,7 @@ function TestRunState(
     token::Union{Nothing,CancellationTokens.CancellationToken}=nothing,
     gc_between_testitems::Bool=false,
     memory_threshold::Union{Nothing,Float64}=nothing,
+    failfast::Bool=false,
 )
     cancellation_source = token === nothing ?
         CancellationTokens.CancellationTokenSource() :
@@ -220,6 +227,8 @@ function TestRunState(
         Set{String}(),                              # reported_items
         gc_between_testitems,
         memory_threshold,
+        failfast,
+        false,                                      # failure_seen
     )
 end
 

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -704,24 +704,28 @@ function handle!(c::TestItemController, msg::ProcsAcquiredMsg)
     return false
 end
 
-function handle!(c::TestItemController, msg::TestRunCancelledMsg)
-    if !haskey(c.test_runs, msg.testrun_id)
-        return false
-    end
-    tr = c.test_runs[msg.testrun_id]
+"""
+Stop a test run: skip every remaining work unit, kill the processes assigned to it and
+signal its completion. Shared by an outside cancellation and by a failfast stop, which
+differ only in `reason` — the run itself is torn down the same way, because a worker holds
+its whole assigned chunk and killing it is the only way to stop it mid-batch.
 
+Runs on the reactor task and is synchronous, so nothing a worker has already queued can be
+processed between the caller's decision to stop and the run reaching `TestRunCancelled`.
+"""
+function _cancel_testrun!(c::TestItemController, tr::TestRunState; reason::Symbol=:cancelled)
     if state(tr.fsm) in (TestRunCancelled, TestRunCompleted)
-        return false
+        return nothing
     end
 
-    @info "Test run cancelled, skipping $(length(tr.remaining_work)) remaining work unit(s)"
+    @info "Test run stopped ($(reason)), skipping $(length(tr.remaining_work)) remaining work unit(s)"
 
     if state(tr.fsm) == TestRunWaitingForProcs
-        transition!(tr.fsm, TestRunCancelled; reason="cancelled before procs acquired")
+        transition!(tr.fsm, TestRunCancelled; reason="$(reason) before procs acquired")
     elseif state(tr.fsm) in (TestRunProcsAcquired, TestRunRunning)
-        transition!(tr.fsm, TestRunCancelled; reason="cancelled")
+        transition!(tr.fsm, TestRunCancelled; reason=string(reason))
     else
-        transition!(tr.fsm, TestRunCancelled; reason="cancelled from $(state(tr.fsm))")
+        transition!(tr.fsm, TestRunCancelled; reason="$(reason) from $(state(tr.fsm))")
     end
 
     CancellationTokens.cancel(tr.cancellation_source)
@@ -729,7 +733,7 @@ function handle!(c::TestItemController, msg::TestRunCancelledMsg)
     # Report all remaining test items as skipped
     for ((testitem_id, test_env_id), _) in tr.remaining_work
         push!(tr.reported_items, testitem_id)
-        _notify_testitem_skipped(c.callbacks, msg.testrun_id, testitem_id, test_env_id)
+        _notify_testitem_skipped(c.callbacks, tr.id, testitem_id, test_env_id)
     end
     empty!(tr.remaining_work)
 
@@ -745,6 +749,21 @@ function handle!(c::TestItemController, msg::TestRunCancelledMsg)
 
     # Signal completion
     _signal_testrun_completion!(tr, nothing)
+    return nothing
+end
+
+# Record that a work unit of this run reported a terminal failure. Only `failfast` runs act
+# on it, in `_check_testrun_complete!`.
+function _note_failure!(tr::TestRunState)
+    tr.failure_seen = true
+    return nothing
+end
+
+function handle!(c::TestItemController, msg::TestRunCancelledMsg)
+    if !haskey(c.test_runs, msg.testrun_id)
+        return false
+    end
+    _cancel_testrun!(c, c.test_runs[msg.testrun_id]; reason=:cancelled)
     return false
 end
 
@@ -1002,6 +1021,7 @@ function handle!(c::TestItemController, msg::TestItemFailedMsg)
         _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
 
         push!(tr.reported_items, msg.testitem_id)
+        _note_failure!(tr)
         _notify_testitem_failed(c.callbacks,
             msg.testrun_id,
             msg.testitem_id,
@@ -1070,6 +1090,7 @@ function handle!(c::TestItemController, msg::TestItemErroredMsg)
         _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
 
         push!(tr.reported_items, msg.testitem_id)
+        _note_failure!(tr)
         _notify_testitem_errored(c.callbacks,
             msg.testrun_id,
             msg.testitem_id,
@@ -1284,6 +1305,7 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
             if haskey(tr.remaining_work, work_key) && item !== nothing
                 delete!(tr.remaining_work, work_key)
                 push!(tr.reported_items, testitem_id)
+                _note_failure!(tr)
                 _notify_testitem_errored(c.callbacks,
                     msg.testrun_id,
                     testitem_id,
@@ -1360,6 +1382,7 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
             "Test process crashed while running test item '$(item_label)'"
         end
         push!(tr.reported_items, crashed_item_id)
+        _note_failure!(tr)
         _notify_testitem_errored(c.callbacks,
             msg.testrun_id,
             crashed_item_id,
@@ -1391,6 +1414,7 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
                 if haskey(tr.remaining_work, work_key) && item !== nothing
                     delete!(tr.remaining_work, work_key)
                     push!(tr.reported_items, testitem_id)
+                    _note_failure!(tr)
                     _notify_testitem_errored(c.callbacks,
                         msg.testrun_id,
                         testitem_id,
@@ -1422,6 +1446,7 @@ function _handle_termination_during_run!(c::TestItemController, msg::TestProcess
                 if haskey(tr.remaining_work, work_key) && item !== nothing
                     delete!(tr.remaining_work, work_key)
                     push!(tr.reported_items, testitem_id)
+                    _note_failure!(tr)
                     _notify_testitem_errored(c.callbacks,
                         msg.testrun_id,
                         testitem_id,
@@ -1635,6 +1660,7 @@ function handle!(c::TestItemController, msg::TestItemTimeoutMsg)
         _remove_from_proc_queue!(tr, msg.testprocess_id, msg.testitem_id)
 
         push!(tr.reported_items, msg.testitem_id)
+        _note_failure!(tr)
         _notify_testitem_errored(c.callbacks,
             msg.testrun_id,
             msg.testitem_id,
@@ -1864,6 +1890,7 @@ function handle!(c::TestItemController, msg::ActivationFailedMsg)
             if haskey(tr.remaining_work, work_key) && item !== nothing
                 delete!(tr.remaining_work, work_key)
                 push!(tr.reported_items, testitem_id)
+                _note_failure!(tr)
                 _notify_testitem_errored(c.callbacks,
                     testrun_id,
                     testitem_id,
@@ -1906,6 +1933,7 @@ function handle!(c::TestItemController, msg::ActivationFailedMsg)
                 if haskey(tr.remaining_work, work_key) && item !== nothing
                     delete!(tr.remaining_work, work_key)
                     push!(tr.reported_items, testitem_id)
+                    _note_failure!(tr)
                     _notify_testitem_errored(c.callbacks,
                         testrun_id,
                         testitem_id,
@@ -2831,6 +2859,13 @@ function _check_testrun_complete!(c::TestItemController, tr::TestRunState)
         end
 
         _signal_testrun_completion!(tr, coverage_results)
+    elseif tr.failfast && tr.failure_seen
+        # The run is not done, but under failfast it is over. Stopping here — synchronously,
+        # on the reactor, in the same step that recorded the failure — is what makes failfast
+        # deterministic: a result the worker has already sent for the next item of its batch
+        # is dropped by the `TestRunCancelled` guard every message handler opens with, instead
+        # of racing a cancellation that a consumer would only be able to append to this queue.
+        _cancel_testrun!(c, tr; reason=:failfast)
     else
         @debug "$(remaining) test item(s) remaining ($(pending_stolen) pending stolen confirmation(s))"
     end
@@ -2862,6 +2897,10 @@ environments use `"Coverage"` mode) or `nothing`.
 
 # Keyword arguments
 - `coverage_root_uris` — if set, only collect coverage for files under these URI prefixes.
+- `failfast` — stop the run as soon as a work unit fails or errors. The remaining work is
+  reported as skipped and the run finishes normally, exactly as an outside cancellation
+  would. The decision is taken on the reactor, in the same step that records the failure, so
+  a result already on its way from a worker cannot slip past it.
 """
 function execute_testrun(
     controller::TestItemController,
@@ -2874,7 +2913,8 @@ function execute_testrun(
     token;
     coverage_root_uris::Union{Nothing,Vector{String}}=nothing,
     gc_between_testitems::Union{Nothing,Bool}=nothing,
-    memory_threshold::Union{Nothing,Float64}=nothing)
+    memory_threshold::Union{Nothing,Float64}=nothing,
+    failfast::Bool=false)
 
     @info "Creating new test run '$(testrun_id)' with $(length(test_items)) test item(s) and $(length(test_environments)) environment(s)"
 
@@ -2893,22 +2933,12 @@ function execute_testrun(
         max_processes;
         coverage_root_uris = coverage_root_uris,
         token = token,
-        memory_threshold = memory_threshold
+        memory_threshold = memory_threshold,
+        failfast = failfast
     )
-
-    # Register cancellation bridge
-    testrun_cancel_registration = nothing
-    if token !== nothing
-        testrun_cancel_registration = CancellationTokens.register(token) do
-            try put!(controller.reactor_channel, TestRunCancelledMsg(testrun_id)) catch end
-        end
-    end
 
     if isempty(test_items)
         @warn "No valid test items to run"
-        if testrun_cancel_registration !== nothing
-            try close(testrun_cancel_registration) catch end
-        end
         return nothing
     end
 
@@ -2947,6 +2977,17 @@ function execute_testrun(
     # Register test run with controller
     controller.test_runs[testrun_id] = tr
     transition!(tr.fsm, TestRunWaitingForProcs; reason="requesting procs")
+
+    # Register the cancellation bridge only now that the run is in `controller.test_runs`
+    # and has left its initial state: `register` invokes its callback immediately when the
+    # token is already cancelled, and a `TestRunCancelledMsg` posted before the run exists
+    # is dropped by the handler's own `haskey` guard — the run would then execute in full.
+    testrun_cancel_registration = nothing
+    if token !== nothing
+        testrun_cancel_registration = CancellationTokens.register(token) do
+            try put!(controller.reactor_channel, TestRunCancelledMsg(testrun_id)) catch end
+        end
+    end
 
     # Build server-side test setup details
     server_test_setups = [

--- a/test/test_cancellation.jl
+++ b/test/test_cancellation.jl
@@ -270,3 +270,106 @@ end
     completed = filter(e -> e.event in (:passed, :failed, :errored, :skipped), events)
     @test length(completed) == length(discovered.items)
 end
+
+@testitem "A run whose token is already cancelled runs nothing" setup=[TestHelpers] begin
+    # Regression: `CancellationTokens.register` invokes its callback immediately for an
+    # already-cancelled token, so the bridge used to post `TestRunCancelledMsg` before the run
+    # was in `controller.test_runs` — the handler's `haskey` guard then dropped it and the run
+    # executed in full. Every item must be skipped and none of them may start.
+    using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown,
+        CancellationTokens, ControllerCallbacks
+    import UUIDs
+
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    events = NamedTuple[]
+    events_lock = ReentrantLock()
+    record = (kind, id) -> lock(events_lock) do; push!(events, (event=kind, testitem_id=id)); end
+
+    callbacks = ControllerCallbacks(
+        on_testitem_started = (run_id, item_id, env_id) -> record(:started, item_id),
+        on_testitem_passed = (run_id, item_id, env_id, duration) -> record(:passed, item_id),
+        on_testitem_failed = (run_id, item_id, env_id, messages, duration) -> record(:failed, item_id),
+        on_testitem_errored = (run_id, item_id, env_id, messages, duration) -> record(:errored, item_id),
+        on_testitem_skipped = (run_id, item_id, env_id) -> record(:skipped, item_id),
+        on_append_output = (run_id, item_id, env_id, output) -> nothing,
+        on_attach_debugger = (run_id, pipe_name) -> nothing,
+    )
+
+    controller = TestItemController(callbacks; log_level=:Debug)
+    test_env = TestHelpers.make_test_environment(; TestHelpers._env_kwargs(discovered)...)
+    work_units = [TestRunItem(item.id, test_env.id, nothing, :Debug) for item in discovered.items]
+
+    cs = CancellationTokens.CancellationTokenSource()
+    CancellationTokens.cancel(cs)   # cancelled *before* the run is submitted
+
+    controller_task = @async try
+        run(controller)
+    catch err
+        @error "Controller error" exception=(err, catch_backtrace())
+    end
+
+    testrun_task = @async execute_testrun(controller, string(UUIDs.uuid4()), [test_env],
+        discovered.items, work_units, discovered.setups, 1, CancellationTokens.get_token(cs))
+
+    TestHelpers.timed_wait(testrun_task, 600; label="precancelled-testrun")
+    shutdown(controller)
+    TestHelpers.timed_wait(controller_task, 600; label="precancelled-controller")
+
+    @test count(e -> e.event === :skipped, events) == length(discovered.items)
+    @test !any(e -> e.event in (:started, :passed, :failed, :errored), events)
+end
+
+@testitem "failfast stops the run at the first failure" setup=[TestHelpers] begin
+    # Every item here fails, and all of them are handed to the one worker as a single batch,
+    # so this only holds if the run is stopped on the reactor in the same step that records
+    # the first failure. A stop requested by a consumer reacting to the callback is appended
+    # to the reactor channel and loses to the next result already queued ahead of it.
+    using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown,
+        ControllerCallbacks
+    import UUIDs
+
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    always_failing = ["failing test", "failing test multiple", "erroring test"]
+    items = filter(i -> i.label in always_failing, discovered.items)
+    @test length(items) == length(always_failing)
+
+    events = NamedTuple[]
+    events_lock = ReentrantLock()
+    record = (kind, id) -> lock(events_lock) do; push!(events, (event=kind, testitem_id=id)); end
+
+    callbacks = ControllerCallbacks(
+        on_testitem_started = (run_id, item_id, env_id) -> record(:started, item_id),
+        on_testitem_passed = (run_id, item_id, env_id, duration) -> record(:passed, item_id),
+        on_testitem_failed = (run_id, item_id, env_id, messages, duration) -> record(:failed, item_id),
+        on_testitem_errored = (run_id, item_id, env_id, messages, duration) -> record(:errored, item_id),
+        on_testitem_skipped = (run_id, item_id, env_id) -> record(:skipped, item_id),
+        on_append_output = (run_id, item_id, env_id, output) -> nothing,
+        on_attach_debugger = (run_id, pipe_name) -> nothing,
+    )
+
+    controller = TestItemController(callbacks; log_level=:Debug)
+    test_env = TestHelpers.make_test_environment(; TestHelpers._env_kwargs(discovered)...)
+    work_units = [TestRunItem(item.id, test_env.id, nothing, :Debug) for item in items]
+
+    controller_task = @async try
+        run(controller)
+    catch err
+        @error "Controller error" exception=(err, catch_backtrace())
+    end
+
+    testrun_task = @async execute_testrun(controller, string(UUIDs.uuid4()), [test_env],
+        items, work_units, discovered.setups, 1, nothing; failfast=true)
+
+    TestHelpers.timed_wait(testrun_task, 600; label="failfast-testrun")
+    shutdown(controller)
+    TestHelpers.timed_wait(controller_task, 600; label="failfast-controller")
+
+    terminal = filter(e -> e.event in (:passed, :failed, :errored, :skipped), events)
+    @test length(terminal) == length(items)
+    @test count(e -> e.event in (:failed, :errored), terminal) == 1
+    @test count(e -> e.event === :skipped, terminal) == length(items) - 1
+end


### PR DESCRIPTION
Two genuine bugs found by the fleet-wide `LintAndTest` sweep, both showing up as
intermittent TestItemApp failures on the slower CI legs (`macos-26-intel` and
`windows-latest` under Julia 1.13.0-rc3). Same failure mode with two entry points: **a stop
request that arrives after the work has already been handed out.**

### 1. An already-cancelled token was dropped on the floor

`CancellationTokens.register` invokes its callback immediately when the source is already
cancelled, so `execute_testrun`'s bridge posted `TestRunCancelledMsg` while the run was
still absent from `controller.test_runs` — and `handle!(::TestRunCancelledMsg)` opens with
a `haskey` guard that discarded it. The run then executed in full.

Evidence: TestItemApp run 32609225891, job 97119408871, testitem *"a cancelled run returns
its partial result and reports it"* — the token is cancelled **before** the run starts, yet
one item passed and one failed instead of every item being skipped.

Fix: register the run and leave its initial state first, then register the bridge. This is
the ordering the guard in `handle!(::GetProcsForTestRunMsg)` already documents in its own
comment.

### 2. Failfast was decided one hop too far away

`_send_run_testitems!` hands a worker its whole assigned chunk in a single batch request, so
`max_workers=1` does not serialize the decision. A consumer reacting to `on_testitem_failed`
can only *append* a cancellation to the reactor queue — and the next item's result may
already be sitting in that queue ahead of it, where it is recorded as a second failure. Pure
queue-ordering luck; no consumer-side change can close it.

Evidence: TestItemApp run 32597212109, job 97089984639, testitem *"run_tests failfast stops
after the first failing test item"* — 2 `:failed` + 1 `:skipped` against a fixture of three
always-failing items run with `failfast=true, max_workers=1`.

Fix: `execute_testrun` takes a `failfast` keyword (default `false`, so every existing caller
is unaffected), and the run is stopped from `_check_testrun_complete!` — synchronously, on
the reactor, in the same step that recorded the failure. A result already in flight is then
dropped by the `TestRunCancelled` guard every handler opens with. The teardown itself is
unchanged, just shared as `_cancel_testrun!`.

`_note_failure!(tr)` is added at all nine sites that report a terminal failure for a work
unit (worker-reported failed/errored, timeout, crash, activation failure, process death), so
the trigger matches the consumer-side semantics it replaces exactly.

### Verification

- Two new regression items in `test/test_cancellation.jl`.
- The pre-cancelled test is **red on `main`** once the losing interleaving is forced (a
  `sleep(0.5)` between the bridge registration and the run registration): the run executes
  the whole suite, 113 s instead of 11 s. With the fix, the same forced interleaving still
  passes and finishes in 2.6 s — order-independent, not merely faster.
- Full TIC suite: 221/221.
- Against a patched TestItemRuns, the full TestItemApp suite is 38/38, including both
  originally failing items; the cancelled-run item drops from actually running tests to 30 ms.

Version bumped to `1.10.0-DEV` for the new keyword. Companion PR:
julia-testitems/TestItemRuns.jl#6 (draft until 1.10.0 is registered).