### PR TITLE
Fix the field name the startup-crash warning reads

### DIFF
--- a/src/testprocess.jl
+++ b/src/testprocess.jl
@@ -490,7 +490,7 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
                     # The only record of why a process died before it could connect. It is
                     # dropped on the floor below, where all that survives is an exit code,
                     # so surface it here while we still have it.
-                    @warn "Test process crashed during startup" testprocess_id exitcode=err.exitcode termsignal=err.termsignal output=_strip_ansi(err.captured_output)
+                    @warn "Test process crashed during startup" testprocess_id exitcode=err.exitcode term_signal=err.term_signal output=_strip_ansi(err.captured_output)
                 end
 
                 if !(err isa CancellationTokens.OperationCanceledException)

--- a/test/test_process_crash.jl
+++ b/test/test_process_crash.jl
@@ -187,3 +187,27 @@ end
     # The crashed process should have been terminated
     @test length(terminated) == 1
 end
+
+@testitem "The startup-crash warning only reads fields the exception has" begin
+    using TestItemControllers: TestProcessCrashException
+
+    # `@warn` swallows an exception thrown while building its own log record: it prints
+    # "Exception while generating log record" and the run carries on. So a mistyped field name
+    # here is invisible until a process actually dies before it can connect — and then it
+    # destroys the one message explaining why, which is the only record that path produces.
+    # That is exactly what happened: `err.termsignal` against a field named `term_signal`.
+    # Read the record back out of the source and check every field it names really exists.
+    source = read(joinpath(pkgdir(TestItemControllers), "src", "testprocess.jl"), String)
+    line = only(filter(l -> occursin("Test process crashed during startup", l), split(source, '\n')))
+
+    fields = [Symbol(m.captures[1]) for m in eachmatch(r"\berr\.([A-Za-z_][A-Za-z0-9_]*)", line)]
+    @test !isempty(fields)
+    for f in fields
+        @test f in fieldnames(TestProcessCrashException)
+    end
+
+    # And the record must still render for a crash that carries an exit code and a signal.
+    err = TestProcessCrashException("tp-1", 139, 11, "boom")
+    @test err.term_signal == 11
+    @test err.exitcode == 139
+end


### PR DESCRIPTION
`TestProcessCrashException` names its field `term_signal`, but the warning at `src/testprocess.jl:493` read `err.termsignal`:

```
┌ Error: Exception while generating log record in module TestItemControllers at .../testprocess.jl:493
│   FieldError: type TestProcessCrashException has no field `termsignal`,
│   available fields: `testprocess_id`, `exitcode`, `term_signal`, `captured_output`
```

`@warn` catches an exception thrown while building its own log record, so this never surfaced as a failure. It printed "Exception while generating log record" and the run carried on — without the one message explaining why the process died. The comment directly above the call says exactly what is at stake:

> The only record of why a process died before it could connect. It is dropped on the floor below, where all that survives is an exit code, so surface it here while we still have it.

## How it turned up

A fleet-wide LintAndTest run across the stack. On TestItems.jl, leg `ubuntu-latest, 1.8.5~x86` ([job](https://github.com/julia-testitems/TestItems.jl/actions/runs/32597217897)), a test process crashed during startup, this diagnostic was destroyed, and the leg then sat silent for six hours until GitHub's job limit killed it — leaving four orphan julia processes behind.

To be clear about scope: the logging macro swallows the `FieldError`, so this typo is **not** the cause of that hang. It is what makes the hang undiagnosable. Three separate 6-hour hangs in that run produced no diagnostics at all; this is the first step toward being able to read them.

## Test

A mistyped field inside a log interpolation is invisible until the unhappy path runs, so asserting on a rendered message would not have caught it either. The test reads the log record back out of the source and checks every `err.<field>` it names against `fieldnames(TestProcessCrashException)`.

Verified it catches the regression: with `err.termsignal` restored the test fails with `Evaluated: termsignal in (:testprocess_id, :exitcode, :term_signal, :captured_output)`; with the fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)