### PR TITLE
Keep the reactor alive when a handler throws

### DIFF
--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -208,9 +208,62 @@ function Base.run(controller::TestItemController)
         msg = take!(controller.reactor_channel)
         @debug "Reactor msg" msg_type=typeof(msg).name.name
 
-        should_stop = handle!(controller, msg)
+        should_stop = try
+            handle!(controller, msg)
+        catch err
+            _handle_reactor_failure!(controller, msg, err, catch_backtrace())
+        end
         should_stop === true && break
     end
+end
+
+# An exception escaping a handler used to kill the reactor loop outright, which failed
+# nothing visibly: every run in flight, and every later `shutdown` call, then waited forever
+# on a channel nothing would ever service again. Two of the handlers carry comments describing
+# exactly that failure mode having happened. So the loop never dies with the controller still
+# running: the failure is logged with its backtrace, the run the message belonged to — when
+# one can be identified — is cancelled so its caller is released, and the loop carries on.
+#
+# The one place carrying on would be wrong is the shutdown path itself: if ShutdownMsg or
+# ShutdownDeadlineMsg failed, the loop would keep waiting for termination messages that the
+# broken handler never arranged, so there the controller is force-stopped instead.
+function _handle_reactor_failure!(c::TestItemController, msg, err, bt)
+    @error "Reactor handler failed; continuing" msg_type=typeof(msg).name.name exception=(err, bt)
+
+    if msg isa ShutdownMsg || msg isa ShutdownDeadlineMsg
+        try
+            for ps in collect(values(c.test_processes))
+                _force_terminate_process!(c, ps; reason="reactor failure during shutdown")
+            end
+        catch cleanup_err
+            @error "Force-termination during reactor failure also failed" exception=(cleanup_err, catch_backtrace())
+        end
+        try
+            # _controller_stopped! transitions ShuttingDown → Stopped; a failure before the
+            # handler reached its own transition leaves the FSM in Running, so step it first.
+            state(c.controller_fsm) == ControllerRunning &&
+                transition!(c.controller_fsm, ControllerShuttingDown; reason="reactor failure during shutdown")
+            _controller_stopped!(c; reason="reactor failure during shutdown")
+        catch stop_err
+            @error "Stopping the controller after a shutdown-path failure also failed" exception=(stop_err, catch_backtrace())
+        end
+        return true
+    end
+
+    testrun_id = hasproperty(msg, :testrun_id) ? msg.testrun_id : nothing
+    if testrun_id === nothing && hasproperty(msg, :testprocess_id)
+        ps = get(c.test_processes, msg.testprocess_id, nothing)
+        ps === nothing || (testrun_id = ps.testrun_id)
+    end
+    if testrun_id !== nothing && haskey(c.test_runs, testrun_id)
+        try
+            _cancel_testrun!(c, c.test_runs[testrun_id]; reason=:reactor_handler_error)
+        catch cancel_err
+            @error "Cancelling the run of a failed reactor message also failed" testrun_id exception=(cancel_err, catch_backtrace())
+        end
+    end
+
+    return false
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/test/test_reactor_resilience.jl
+++ b/test/test_reactor_resilience.jl
@@ -1,0 +1,54 @@
+@testitem "A failing handler does not kill the reactor" begin
+    using TestItemControllers: TestItemController, ControllerCallbacks, ReactorMessage,
+        ShutdownMsg, state, ControllerStopped
+
+    noop_callbacks() = ControllerCallbacks(;
+        on_testitem_started = (args...) -> nothing,
+        on_testitem_passed = (args...) -> nothing,
+        on_testitem_failed = (args...) -> nothing,
+        on_testitem_errored = (args...) -> nothing,
+        on_testitem_skipped = (args...) -> nothing,
+        on_append_output = (args...) -> nothing,
+        on_attach_debugger = (args...) -> nothing,
+    )
+
+    # A message no handler knows produces a MethodError inside the loop — the same shape as
+    # any unforeseen handler failure. The loop used to die on it, silently converting every
+    # in-flight run and every later `shutdown` into a permanent hang; now it logs and keeps
+    # serving, so the shutdown that follows must still be processed and the loop must return.
+    struct BoomMsg <: ReactorMessage end
+
+    controller = TestItemController(noop_callbacks())
+    reactor_task = @async run(controller)
+
+    put!(controller.reactor_channel, BoomMsg())
+    put!(controller.reactor_channel, ShutdownMsg())
+
+    @test timedwait(() -> istaskdone(reactor_task), 60.0) === :ok
+    @test !istaskfailed(reactor_task)
+    @test state(controller.controller_fsm) == ControllerStopped
+end
+
+@testitem "A failure while shutting down still stops the controller" begin
+    using TestItemControllers: TestItemController, ControllerCallbacks,
+        ShutdownMsg, state, ControllerStopped
+
+    noop_callbacks() = ControllerCallbacks(;
+        on_testitem_started = (args...) -> nothing,
+        on_testitem_passed = (args...) -> nothing,
+        on_testitem_failed = (args...) -> nothing,
+        on_testitem_errored = (args...) -> nothing,
+        on_testitem_skipped = (args...) -> nothing,
+        on_append_output = (args...) -> nothing,
+        on_attach_debugger = (args...) -> nothing,
+    )
+
+    # If the shutdown path itself fails, carrying on would wait forever for termination
+    # messages the broken handler never arranged — there the reactor force-stops instead.
+    # Drive the failure handler directly, as the loop does after a ShutdownMsg handler throws.
+    controller = TestItemController(noop_callbacks())
+    stopped = TestItemControllers._handle_reactor_failure!(
+        controller, ShutdownMsg(), ErrorException("boom"), Base.catch_backtrace())
+    @test stopped === true
+    @test state(controller.controller_fsm) == ControllerStopped
+end


### PR DESCRIPTION
First of two safety nets from the CI-hang investigation (the second, a run-progress heartbeat, follows as a separate PR).

An exception escaping any `handle!` killed the reactor loop outright — `Base.run(controller)` had no try/catch. That failed nothing visibly: every run in flight, and every later `shutdown` call, then waited forever on a channel nothing would ever service again. The comments on the `ShutdownMsg` handler and on `_check_testrun_complete!` both record this exact failure mode having happened before; each time the fix was to harden that one handler. This closes the class instead.

## Behaviour

- A handler exception is logged with its full backtrace (`Reactor handler failed; continuing`), the run the message belonged to is cancelled when one can be identified from `testrun_id`/`testprocess_id` — releasing the caller blocked in `execute_testrun` — and the loop keeps serving.
- The exception to carrying on is the shutdown path itself: a failure while handling `ShutdownMsg`/`ShutdownDeadlineMsg` force-terminates the remaining processes and stops the controller, since continuing would wait for termination messages the broken handler never arranged.

## Why now

The debug-traced Salsa hang (run 32624287786) showed the reactor *idle*, not dead — so this net would not have caught that particular hang (the heartbeat PR is for that one). But the two historical incidents in the code comments are this exact shape, and any future handler bug currently converts into a silent 6-hour CI burn. The two nets together cover both failure modes: reactor dead, and reactor idle with nothing to wake it.

## Tests

- `A failing handler does not kill the reactor`: posts a message no handler knows (a `MethodError` inside the loop — the same shape as any unforeseen failure), then a `ShutdownMsg`; asserts the loop survives the first, processes the second, and stops cleanly.
- `A failure while shutting down still stops the controller`: drives the failure path for `ShutdownMsg` directly and asserts the controller ends in `ControllerStopped`.

Full suite locally: 224/224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)