### PR TITLE
Fail a run the reactor has heard nothing about, instead of waiting forever

### DIFF
--- a/src/messages.jl
+++ b/src/messages.jl
@@ -11,6 +11,10 @@ struct ShutdownMsg <: ReactorMessage end
 # it arrives, they are force-killed and dropped so the reactor loop is guaranteed to exit.
 struct ShutdownDeadlineMsg <: ReactorMessage end
 
+# Posted by the controller's repeating heartbeat timer. The handler checks every active test
+# run for lack of progress; see `handle!(::HeartbeatMsg)`.
+struct HeartbeatMsg <: ReactorMessage end
+
 struct GetProcsForTestRunMsg <: ReactorMessage
     testrun_id::String
     proc_count_by_env::Dict{ProcessEnv,Int}

--- a/src/state.jl
+++ b/src/state.jl
@@ -134,6 +134,11 @@ mutable struct TestRunState
     # may already be queued ahead of it and would be recorded as a second failure.
     failfast::Bool
     failure_seen::Bool
+    # Liveness bookkeeping for the reactor heartbeat: when the last message affecting this
+    # run was processed, and whether the stall warning for the current quiet spell has
+    # already been emitted. See `handle!(::HeartbeatMsg)`.
+    last_activity::Float64
+    stall_warned::Bool
 end
 
 """
@@ -229,6 +234,8 @@ function TestRunState(
         memory_threshold,
         failfast,
         false,                                      # failure_seen
+        time(),                                     # last_activity
+        false,                                      # stall_warned
     )
 end
 

--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -8,6 +8,13 @@ const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0
 # it says so anyway.
 const DEFAULT_ACTIVATION_PROGRESS_SECONDS = 120.0
 
+# How long a test run may go without the reactor processing a single message that concerns
+# it before the heartbeat first warns, and — at twice this — fails the run. The CI hangs
+# this bounds were runs whose workers died without their IO tasks ever reporting it: the
+# reactor sat idle, with remaining work, for six hours until GitHub killed the job. The
+# heartbeat turns that into a loud, attributed failure in minutes.
+const DEFAULT_RUN_STALL_SECONDS = 300.0
+
 """
     TestItemController(callbacks; error_handler_file=nothing, crash_reporting_pipename=nothing, log_level=:Info)
 
@@ -43,6 +50,12 @@ the reactor event loop, then use [`execute_testrun`](@ref) to submit work.
   activation is a precompilation, and no one number fits every project. Set it where a stalled
   activation would otherwise burn a whole CI job, which nothing else covers — the per-item
   timeout cannot fire, because no item has started.
+- `run_stall_seconds::Union{Nothing,Real}` — how long a test run may go without the reactor
+  processing a single message that concerns it before the heartbeat warns with a full
+  process dump, and — at twice this — errors its remaining items and cancels it (default
+  300; `nothing` disables). Unlike every other deadline here this one is on by default: it
+  fires only when *nothing whatsoever* is happening to a run that still has work, which is
+  never legitimate, whereas any single slow step is.
 
 # Lifecycle
 
@@ -96,6 +109,10 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
     # for no limit — the default, matching the per-test-item timeout.
     activation_timeout_seconds::Union{Nothing,Float64}
 
+    # See DEFAULT_RUN_STALL_SECONDS; `nothing` disables the heartbeat entirely.
+    run_stall_seconds::Union{Nothing,Float64}
+    heartbeat_timer::Union{Nothing,Timer}
+
     # Scheduling history, in memory and keyed by the (stable) test item id. It survives
     # across the test runs of one session; nothing is persisted to disk.
     schedule::Symbol
@@ -111,7 +128,8 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
         schedule::Symbol=:duration,
         shutdown_grace_seconds::Real=DEFAULT_SHUTDOWN_GRACE_SECONDS,
         activation_progress_seconds::Real=DEFAULT_ACTIVATION_PROGRESS_SECONDS,
-        activation_timeout_seconds::Union{Nothing,Real}=nothing) where {CB<:ControllerCallbacks}
+        activation_timeout_seconds::Union{Nothing,Real}=nothing,
+        run_stall_seconds::Union{Nothing,Real}=DEFAULT_RUN_STALL_SECONDS) where {CB<:ControllerCallbacks}
 
         schedule in (:duration, :contiguous) ||
             throw(ArgumentError("schedule must be :duration or :contiguous, got $(repr(schedule))"))
@@ -121,8 +139,10 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
             throw(ArgumentError("activation_progress_seconds must be positive, got $(activation_progress_seconds)"))
         activation_timeout_seconds === nothing || activation_timeout_seconds > 0 ||
             throw(ArgumentError("activation_timeout_seconds must be positive or nothing, got $(activation_timeout_seconds)"))
+        run_stall_seconds === nothing || run_stall_seconds > 0 ||
+            throw(ArgumentError("run_stall_seconds must be positive or nothing, got $(run_stall_seconds)"))
 
-        return new{CB}(
+        c = new{CB}(
             callbacks,
             Channel{ReactorMessage}(Inf),
             Dict{String,TestProcessState}(),
@@ -139,11 +159,28 @@ mutable struct TestItemController{CB<:ControllerCallbacks}
             nothing,
             Float64(activation_progress_seconds),
             activation_timeout_seconds === nothing ? nothing : Float64(activation_timeout_seconds),
+            run_stall_seconds === nothing ? nothing : Float64(run_stall_seconds),
+            nothing,                                        # heartbeat_timer
             schedule,
             Dict{String,Symbol}(),
             Dict{String,Float64}(),
             Dict{Tuple{String,String},Float64}(),
         )
+
+        if c.run_stall_seconds !== nothing
+            # Beat at half the stall threshold so a stall is noticed at most 1.5× the
+            # threshold after it began. The channel outlives the timer, so the callback
+            # guards against posting into a closed one during teardown.
+            reactor_channel = c.reactor_channel
+            c.heartbeat_timer = Timer(c.run_stall_seconds / 2; interval=c.run_stall_seconds / 2) do _
+                try
+                    put!(reactor_channel, HeartbeatMsg())
+                catch
+                end
+            end
+        end
+
+        return c
     end
 end
 
@@ -213,6 +250,7 @@ function Base.run(controller::TestItemController)
         catch err
             _handle_reactor_failure!(controller, msg, err, catch_backtrace())
         end
+        _touch_run_activity!(controller, msg)
         should_stop === true && break
     end
 end
@@ -327,7 +365,89 @@ function _controller_stopped!(c::TestItemController; reason::String)
         try close(c.shutdown_timer) catch end
         c.shutdown_timer = nothing
     end
+    if c.heartbeat_timer !== nothing
+        try close(c.heartbeat_timer) catch end
+        c.heartbeat_timer = nothing
+    end
     transition!(c.controller_fsm, ControllerStopped; reason=reason)
+    return nothing
+end
+
+# Record, centrally rather than in thirty handlers, that the reactor just processed a
+# message concerning a run. Anything counts as progress — worker output included — because
+# the stall the heartbeat hunts is total silence: a run whose workers will never send
+# another message of any kind.
+function _touch_run_activity!(c::TestItemController, msg)
+    msg isa HeartbeatMsg && return nothing
+    testrun_id = hasproperty(msg, :testrun_id) ? msg.testrun_id : nothing
+    if testrun_id === nothing && hasproperty(msg, :testprocess_id)
+        ps = get(c.test_processes, msg.testprocess_id, nothing)
+        ps === nothing || (testrun_id = ps.testrun_id)
+    end
+    testrun_id === nothing && return nothing
+    tr = get(c.test_runs, testrun_id, nothing)
+    tr === nothing && return nothing
+    tr.last_activity = time()
+    tr.stall_warned = false
+    return nothing
+end
+
+# The liveness backstop the CI hangs were missing. Every deadline the controller had was
+# scoped to one step — an item, an activation, the shutdown drain — and each depended on
+# some specific message arriving to arm or serve it. A worker that died without its IO task
+# reporting it produced no message at all, so a run could hold remaining work forever while
+# the reactor idled. The heartbeat asks the one question none of those deadlines ask: has
+# *anything* happened to this run lately? One quiet threshold warns with a full dump; twice
+# the threshold fails the remaining items and cancels the run — and the cancellation also
+# releases IO tasks stuck reading from a dead worker, which is how the original hang's
+# missing termination messages finally surfaced when CI cancelled the job.
+function handle!(c::TestItemController, ::HeartbeatMsg)
+    c.run_stall_seconds === nothing && return false
+    state(c.controller_fsm) != ControllerRunning && return false
+
+    now = time()
+    for tr in collect(values(c.test_runs))
+        state(tr.fsm) in (TestRunCancelled, TestRunCompleted) && continue
+        # A debug run paused at a breakpoint is legitimately silent for as long as the user
+        # cares to stare at it — the one case where total quiet is not a fault.
+        any(env -> env.mode == "Debug", tr.test_environments) && continue
+        idle = now - tr.last_activity
+        if idle >= 2 * c.run_stall_seconds
+            @error "Test run has made no progress; failing its remaining items" testrun_id=tr.id idle_seconds=round(idle; digits=1) remaining_work=length(tr.remaining_work) processes=_stall_process_dump(c, tr)
+            _fail_stalled_testrun!(c, tr, idle)
+        elseif idle >= c.run_stall_seconds && !tr.stall_warned
+            tr.stall_warned = true
+            @warn "Test run has made no progress" testrun_id=tr.id idle_seconds=round(idle; digits=1) remaining_work=length(tr.remaining_work) processes=_stall_process_dump(c, tr)
+        end
+    end
+    return false
+end
+
+_stall_process_dump(c::TestItemController, tr::TestRunState) = [
+    (
+        id = ps.id,
+        state = string(state(ps.fsm)),
+        current_testitem = something(ps.current_testitem_id, "none"),
+        seconds_since_message = ps.last_message_at === nothing ? nothing : round(time() - ps.last_message_at; digits=1),
+        seconds_since_output = ps.last_output_at === nothing ? nothing : round(time() - ps.last_output_at; digits=1),
+    )
+    for ps in values(c.test_processes) if ps.testrun_id == tr.id
+]
+
+function _fail_stalled_testrun!(c::TestItemController, tr::TestRunState, idle_seconds::Float64)
+    explanation = "Test run stalled: the controller processed no message concerning this run for $(round(idle_seconds; digits=1)) seconds. " *
+        "A test process most likely died or wedged without reporting it; this item never produced a result."
+    for (testitem_id, test_env_id) in collect(keys(tr.remaining_work))
+        delete!(tr.remaining_work, (testitem_id, test_env_id))
+        push!(tr.reported_items, testitem_id)
+        _note_failure!(tr)
+        _notify_testitem_errored(c.callbacks, tr.id, testitem_id, test_env_id,
+            TestMessage[TestMessage(explanation, nothing, nothing, nothing, nothing, nothing, nothing)],
+            nothing)
+    end
+    # Cancelling also cancels the run token, which releases any IO task still blocked on a
+    # dead worker's pipe, and signals completion so the caller in execute_testrun returns.
+    _cancel_testrun!(c, tr; reason=:stalled)
     return nothing
 end
 

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -373,7 +373,7 @@
     # the second run gets the pooled, already-warm test process of the first. `runs` in the
     # returned value holds the per-run events and output; `events`/`outputs` are the union
     # across runs, which is what a single-run caller wants.
-    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false, activation_progress_seconds=nothing, activation_timeout_seconds=nothing)
+    function run_testrun(items, setups; mode="Run", max_procs=1, timeout=600, coverage_root_uris=nothing, log_level=:Debug, julia_cmd=joinpath(Sys.BINDIR, "julia"), julia_args=String[], env=Dict{String,Union{String,Nothing}}(), item_timeouts=Dict{String,Float64}(), package_name="", package_uri="", project_uri=nothing, env_content_hash=nothing, n_runs=1, gc_between_testitems=nothing, memory_threshold=nothing, shutdown_timeout=60, color::Bool=false, activation_progress_seconds=nothing, activation_timeout_seconds=nothing, run_stall_seconds=:default)
         events = NamedTuple[]
         events_lock = ReentrantLock()
         push_event!(e) = lock(events_lock) do
@@ -426,9 +426,10 @@
             end
         end
 
+        stall_kw = run_stall_seconds === :default ? (;) : (; run_stall_seconds=run_stall_seconds)
         controller = activation_progress_seconds === nothing ?
-            TestItemController(callbacks; log_level=log_level, activation_timeout_seconds=activation_timeout_seconds) :
-            TestItemController(callbacks; log_level=log_level, activation_progress_seconds=activation_progress_seconds, activation_timeout_seconds=activation_timeout_seconds)
+            TestItemController(callbacks; log_level=log_level, activation_timeout_seconds=activation_timeout_seconds, stall_kw...) :
+            TestItemController(callbacks; log_level=log_level, activation_progress_seconds=activation_progress_seconds, activation_timeout_seconds=activation_timeout_seconds, stall_kw...)
         test_env = make_test_environment(; mode=mode, julia_cmd=julia_cmd, julia_args=julia_args, env=env, package_name=package_name, package_uri=package_uri, project_uri=project_uri, env_content_hash=env_content_hash, color=color)
 
         # Build work units from items

--- a/test/test_run_stall.jl
+++ b/test/test_run_stall.jl
@@ -1,0 +1,94 @@
+@testitem "Heartbeat warns on a quiet run and fails a silent one" begin
+    using TestItemControllers: TestItemController, ControllerCallbacks, TestRunState,
+        TestEnvironment, TestItemDetail, TestRunItem, TestSetupDetail, HeartbeatMsg,
+        handle!, state, TestRunCancelled, TestRunCreated
+
+    errored = Tuple{String,String}[]
+    callbacks = ControllerCallbacks(;
+        on_testitem_started = (args...) -> nothing,
+        on_testitem_passed = (args...) -> nothing,
+        on_testitem_failed = (args...) -> nothing,
+        on_testitem_errored = (run_id, item_id, env_id, messages, duration, perf...) ->
+            push!(errored, (item_id, messages[1].message)),
+        on_testitem_skipped = (args...) -> nothing,
+        on_append_output = (args...) -> nothing,
+        on_attach_debugger = (args...) -> nothing,
+    )
+
+    # No reactor is running: the handler is driven directly, so the timing is simulated by
+    # setting last_activity rather than by sleeping.
+    c = TestItemController(callbacks; run_stall_seconds=10.0)
+    try
+        tr = TestRunState("stall-run", TestEnvironment[], TestItemDetail[], TestRunItem[],
+            TestSetupDetail[], 1)
+        c.test_runs["stall-run"] = tr
+
+        # Fresh run: nothing happens.
+        handle!(c, HeartbeatMsg())
+        @test !tr.stall_warned
+        @test state(tr.fsm) == TestRunCreated
+
+        # Past one threshold: warned once, still running.
+        tr.last_activity = time() - 11.0
+        handle!(c, HeartbeatMsg())
+        @test tr.stall_warned
+        @test state(tr.fsm) == TestRunCreated
+
+        # Activity resets the warning.
+        tr.last_activity = time()
+        tr.stall_warned = false
+        handle!(c, HeartbeatMsg())
+        @test !tr.stall_warned
+
+        # A Debug run is exempt: paused at a breakpoint, silence is legitimate.
+        debug_env = TestEnvironment("dbg-env", "julia", String[], nothing,
+            Dict{String,Union{String,Nothing}}(), "Debug", "Pkg", "file:///pkg", nothing,
+            nothing, nothing, false)
+        tr_dbg = TestRunState("dbg-run", [debug_env], TestItemDetail[], TestRunItem[],
+            TestSetupDetail[], 1)
+        c.test_runs["dbg-run"] = tr_dbg
+        tr_dbg.last_activity = time() - 1000.0
+        handle!(c, HeartbeatMsg())
+        @test !tr_dbg.stall_warned
+        @test state(tr_dbg.fsm) == TestRunCreated
+
+        # Past twice the threshold: the run is failed and its caller released.
+        tr.last_activity = time() - 21.0
+        handle!(c, HeartbeatMsg())
+        @test state(tr.fsm) == TestRunCancelled
+        @test isready(tr.completion_channel)
+    finally
+        # Stop the heartbeat timer.
+        c.heartbeat_timer === nothing || close(c.heartbeat_timer)
+    end
+end
+
+@testitem "A worker that never connects fails the run instead of hanging it" setup=[TestHelpers] begin
+    # The CI hang in one sentence: a test process that is alive but will never send a
+    # message again, while the run still has remaining work. Nothing item-scoped can fire —
+    # no item ever started — and before the heartbeat the reactor idled on it forever
+    # (6 hours, until GitHub killed the job). Simulate it exactly: `-e "sleep(600)"` makes
+    # the child treat the test-server script as ARGS and just sleep, so it launches fine and
+    # never connects.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+    items = filter(i -> i.label == "add works", discovered.items)
+    @test length(items) == 1
+
+    started = time()
+    result = TestHelpers.run_testrun(items, discovered.setups, discovered;
+        max_procs=1,
+        julia_args=["-e", "sleep(600)"],
+        run_stall_seconds=5,
+        timeout=300,
+    )
+    elapsed = time() - started
+
+    terminal = filter(e -> e.event in (:errored, :failed, :passed, :skipped), result.events)
+    @test length(terminal) == 1
+    @test terminal[1].event == :errored
+    @test occursin("stalled", terminal[1].messages[1].message)
+    # Failed by the heartbeat (≈2×5 s + one beat), not by the 300 s harness timeout and
+    # nowhere near the 600 s the wedged worker would sleep.
+    @test elapsed < 120
+end


### PR DESCRIPTION
Second of the two safety nets from the CI-hang investigation. **Stacked on #90** (base branch is `fix/immortal-reactor`); once #90 merges I'll retarget this to `main` — or merge #90 first and this becomes a plain PR.

## The hole this closes

Every deadline the controller had was scoped to one step — an item, an activation, the shutdown drain — and each depended on some specific message arriving to arm or serve it. A worker that dies without its IO task reporting it produces **no message at all**, so a run could hold remaining work forever while the reactor idled. Three fleet-run legs did exactly that for six hours each, in total silence; the debug trace of the Salsa `windows-latest 1.12.7~x64` leg shows the reactor processing its last message at 13:16:12 and its next — the cancellation — at 19:07:10.

The heartbeat asks the one question none of those deadlines ask: *has anything happened to this run lately?*

## Mechanics

- A repeating timer posts `HeartbeatMsg`; the reactor loop centrally records which run each processed message concerned (any message counts — worker output included — because the stall being hunted is total silence).
- `run_stall_seconds` (controller keyword, default **300**, `nothing` disables). One threshold quiet → `@warn` with a per-process dump: FSM state, current item, seconds since last message/output. Twice the threshold → remaining items errored with an explanatory message, run cancelled. The cancellation also releases IO tasks still blocked on a dead worker's pipe — which is exactly how the real hang's missing `TestProcessTerminatedMsg`s finally surfaced when CI cancelled the job — and returns the caller in `execute_testrun`.
- **On by default**, unlike the step-scoped deadlines: those interrupt a single slow step, which can be legitimate (a long precompile, a slow item), while this fires only when *nothing whatsoever* is happening to a run that still has work.
- **Debug runs are exempt**: paused at a breakpoint, silence is exactly what the user asked for. Without this the default-on heartbeat would kill interactive debug sessions after 10 minutes.

## Tests

- Unit: drives the handler directly — fresh run untouched, warn at 1×, warning reset by activity, Debug run exempt at any idle, fail + caller release at 2×.
- End-to-end: reproduces the CI hang shape precisely — a worker launched with `julia_args=["-e", "sleep(600)"]` is alive but never connects, so nothing item-scoped can ever fire. The run now errors its item with the stall explanation in ~30 s instead of hanging until the harness timeout.

Full suite locally: **226/226**.

## What this does not do

It does not fix the root cause the trace identified (a killed worker's IO task never observing the death on Windows, so the kill→terminated handoff never completes). That fix comes separately; this net is what guarantees that bug — and any sibling we have not found yet — costs minutes and produces a dump, not six silent hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)