### PR TITLE
Never call a run stalled while a worker is busy on it

### DIFF
--- a/src/testitemcontroller.jl
+++ b/src/testitemcontroller.jl
@@ -8,11 +8,12 @@ const DEFAULT_SHUTDOWN_GRACE_SECONDS = 30.0
 # it says so anyway.
 const DEFAULT_ACTIVATION_PROGRESS_SECONDS = 120.0
 
-# How long a test run may go without the reactor processing a single message that concerns
-# it before the heartbeat first warns, and — at twice this — fails the run. The CI hangs
-# this bounds were runs whose workers died without their IO tasks ever reporting it: the
-# reactor sat idle, with remaining work, for six hours until GitHub killed the job. The
-# heartbeat turns that into a loud, attributed failure in minutes.
+# How long a test run may go with nothing happening to it before the heartbeat first warns,
+# and — at twice this — fails the run. The CI hangs this bounds were runs whose workers died
+# without their IO tasks ever reporting it: the reactor sat idle, with remaining work, for six
+# hours until GitHub killed the job. The heartbeat turns that into a loud, attributed failure
+# in minutes. It can stay this short only because it never counts time in which a worker is
+# busy — see `_run_has_busy_process`.
 const DEFAULT_RUN_STALL_SECONDS = 300.0
 
 """
@@ -50,12 +51,13 @@ the reactor event loop, then use [`execute_testrun`](@ref) to submit work.
   activation is a precompilation, and no one number fits every project. Set it where a stalled
   activation would otherwise burn a whole CI job, which nothing else covers — the per-item
   timeout cannot fire, because no item has started.
-- `run_stall_seconds::Union{Nothing,Real}` — how long a test run may go without the reactor
-  processing a single message that concerns it before the heartbeat warns with a full
-  process dump, and — at twice this — errors its remaining items and cancels it (default
-  300; `nothing` disables). Unlike every other deadline here this one is on by default: it
-  fires only when *nothing whatsoever* is happening to a run that still has work, which is
-  never legitimate, whereas any single slow step is.
+- `run_stall_seconds::Union{Nothing,Real}` — how long a test run may go with nothing
+  happening to it before the heartbeat warns with a full process dump, and — at twice this —
+  errors its remaining items and cancels it (default 300; `nothing` disables). Unlike every
+  other deadline here this one is on by default, which it can only afford to be because a
+  process that is *waiting on a worker operation* — activating, revising, running an item —
+  counts as progress for as long as that operation lasts. What is left is a run that holds
+  work while no worker is doing anything about it, which is never legitimate.
 
 # Lifecycle
 
@@ -375,8 +377,9 @@ end
 
 # Record, centrally rather than in thirty handlers, that the reactor just processed a
 # message concerning a run. Anything counts as progress — worker output included — because
-# the stall the heartbeat hunts is total silence: a run whose workers will never send
-# another message of any kind.
+# the stall the heartbeat hunts is a run that nothing is working on. Messages are only half
+# of that picture; the other half is `_run_has_busy_process`, for the stages that produce no
+# message at all for as long as they last.
 function _touch_run_activity!(c::TestItemController, msg)
     msg isa HeartbeatMsg && return nothing
     testrun_id = hasproperty(msg, :testrun_id) ? msg.testrun_id : nothing
@@ -392,13 +395,45 @@ function _touch_run_activity!(c::TestItemController, msg)
     return nothing
 end
 
+# Phases in which the controller is waiting on a worker operation it has already handed
+# over. Each produces no reactor message for as long as it lasts, and each is either guarded
+# by a deadline of its own or deliberately unbounded, so none of them is the heartbeat's
+# business:
+#
+#   * `ProcessActivatingEnv` — bounded by `activation_timeout_seconds`, whose default of
+#     `nothing` is a deliberate choice, because an activation covers a precompilation;
+#   * `ProcessWaitingForPrecompile` — waiting on another process that is itself activating;
+#   * `ProcessRevising` — a Revise pass over changed files;
+#   * `ProcessRunning` — bounded by the test item's own timeout.
+#
+# Every remaining phase is either transient controller-side bookkeeping or `ProcessStarting`,
+# where a worker that never connects is exactly the hang this heartbeat exists to catch.
+const BUSY_PROCESS_PHASES = (
+    ProcessRevising,
+    ProcessWaitingForPrecompile,
+    ProcessActivatingEnv,
+    ProcessRunning,
+)
+
+# Is any worker on this run mid-operation? Without this the heartbeat measured reactor
+# silence, which a healthy cold-cache CI run produces in bulk: an activation is a single
+# async JSON-RPC round trip, so between the "Activating" status and the activation landing
+# nothing reaches the reactor at all. In run 32794123684 of ModelPredictiveControl.jl every
+# leg spent 660-1100s there, and two were killed mid-precompile with all 98 items errored —
+# while the controller was logging "Environment activation still pending, is_precompile =
+# true" every two minutes. A long test item that prints nothing had the same problem: output
+# counts as activity, so only the silent ones tripped it.
+_run_has_busy_process(c::TestItemController, tr::TestRunState) = any(
+    ps -> ps.testrun_id == tr.id && state(ps.fsm) in BUSY_PROCESS_PHASES,
+    values(c.test_processes))
+
 # The liveness backstop the CI hangs were missing. Every deadline the controller had was
 # scoped to one step — an item, an activation, the shutdown drain — and each depended on
 # some specific message arriving to arm or serve it. A worker that died without its IO task
 # reporting it produced no message at all, so a run could hold remaining work forever while
-# the reactor idled. The heartbeat asks the one question none of those deadlines ask: has
-# *anything* happened to this run lately? One quiet threshold warns with a full dump; twice
-# the threshold fails the remaining items and cancels the run — and the cancellation also
+# the reactor idled. The heartbeat asks the one question none of those deadlines ask: is
+# anything at all working on this run? One quiet threshold warns with a full dump; twice the
+# threshold fails the remaining items and cancels the run — and the cancellation also
 # releases IO tasks stuck reading from a dead worker, which is how the original hang's
 # missing termination messages finally surfaced when CI cancelled the job.
 function handle!(c::TestItemController, ::HeartbeatMsg)
@@ -411,6 +446,14 @@ function handle!(c::TestItemController, ::HeartbeatMsg)
         # A debug run paused at a breakpoint is legitimately silent for as long as the user
         # cares to stare at it — the one case where total quiet is not a fault.
         any(env -> env.mode == "Debug", tr.test_environments) && continue
+        # A busy worker is progress, and it restarts the clock rather than merely skipping
+        # this tick: when the operation finishes, the run gets the whole threshold again
+        # before anything calls it stalled.
+        if _run_has_busy_process(c, tr)
+            tr.last_activity = now
+            tr.stall_warned = false
+            continue
+        end
         idle = now - tr.last_activity
         if idle >= 2 * c.run_stall_seconds
             @error "Test run has made no progress; failing its remaining items" testrun_id=tr.id idle_seconds=round(idle; digits=1) remaining_work=length(tr.remaining_work) processes=_stall_process_dump(c, tr)
@@ -435,8 +478,15 @@ _stall_process_dump(c::TestItemController, tr::TestRunState) = [
 ]
 
 function _fail_stalled_testrun!(c::TestItemController, tr::TestRunState, idle_seconds::Float64)
-    explanation = "Test run stalled: the controller processed no message concerning this run for $(round(idle_seconds; digits=1)) seconds. " *
-        "A test process most likely died or wedged without reporting it; this item never produced a result."
+    # Name what the processes were actually doing. The first version of this said a process
+    # "most likely died or wedged", which was flatly wrong every time the heartbeat misfired.
+    procs = _stall_process_dump(c, tr)
+    doing = isempty(procs) ? "The run had no test process at all." :
+        "Test processes: " * join(
+            ("$(p.id) $(p.state)" * (p.current_testitem == "none" ? "" : " on '$(p.current_testitem)'") for p in procs),
+            ", ") * "."
+    explanation = "Test run stalled: for $(round(idle_seconds; digits=1)) seconds no worker was busy on this run and the controller heard nothing about it. " *
+        "$(doing) A test process most likely died or wedged without reporting it; this item never produced a result."
     for (testitem_id, test_env_id) in collect(keys(tr.remaining_work))
         delete!(tr.remaining_work, (testitem_id, test_env_id))
         push!(tr.reported_items, testitem_id)

--- a/test/test_run_stall.jl
+++ b/test/test_run_stall.jl
@@ -92,3 +92,144 @@ end
     # nowhere near the 600 s the wedged worker would sleep.
     @test elapsed < 120
 end
+
+@testitem "A busy test process is progress, however quiet the reactor is" begin
+    using TestItemControllers: TestItemController, ControllerCallbacks, TestRunState,
+        TestEnvironment, TestItemDetail, TestRunItem, TestSetupDetail, HeartbeatMsg,
+        TestProcessState, ProcessEnv, BUSY_PROCESS_PHASES, ProcessStarting,
+        ProcessActivatingEnv, ProcessWaitingForPrecompile, ProcessRevising, ProcessRunning,
+        ProcessReviseOrStart, ProcessConfiguringTestRun, ProcessReadyToRun,
+        handle!, state, transition!, TestRunCancelled, TestRunCreated
+
+    # The regression this guards: on a cold cache every leg of
+    # ModelPredictiveControl.jl run 32794123684 sat in `ProcessActivatingEnv` for 660-1100s
+    # while its worker precompiled, which produces no reactor message at all. Two of them
+    # were killed mid-precompile with every one of their 98 items errored.
+    noop = (args...) -> nothing
+    errored = String[]
+    callbacks = ControllerCallbacks(;
+        on_testitem_started = noop, on_testitem_passed = noop, on_testitem_failed = noop,
+        on_testitem_errored = (run_id, item_id, env_id, messages, duration, perf...) ->
+            push!(errored, messages[1].message),
+        on_testitem_skipped = noop, on_append_output = noop, on_attach_debugger = noop,
+    )
+
+    env = TestEnvironment("env-1", "julia", String[], nothing,
+        Dict{String,Union{String,Nothing}}(), "Normal", "Pkg", "file:///pkg", nothing,
+        nothing, nothing, false)
+
+    function fresh_controller()
+        c = TestItemController(callbacks; run_stall_seconds=10.0)
+        tr = TestRunState("run-1", [env], TestItemDetail[], TestRunItem[],
+            TestSetupDetail[], 1)
+        c.test_runs["run-1"] = tr
+        ps = TestProcessState("proc-1", ProcessEnv(env))
+        ps.testrun_id = "run-1"
+        c.test_processes["proc-1"] = ps
+        return (c, tr, ps)
+    end
+
+    # The FSM only accepts legal transitions, so each phase is reached the way a real
+    # process reaches it.
+    PATH_TO = Dict(
+        ProcessRevising              => [ProcessReviseOrStart, ProcessRevising],
+        ProcessWaitingForPrecompile  => [ProcessStarting, ProcessWaitingForPrecompile],
+        ProcessActivatingEnv         => [ProcessStarting, ProcessActivatingEnv],
+        ProcessRunning               => [ProcessStarting, ProcessActivatingEnv,
+                                         ProcessConfiguringTestRun, ProcessReadyToRun,
+                                         ProcessRunning],
+    )
+    drive_to!(ps, phase) = foreach(p -> transition!(ps.fsm, p), PATH_TO[phase])
+
+    # Every phase in which the controller is waiting on the worker exempts the run, no
+    # matter how far past twice the threshold it is.
+    @test issetequal(keys(PATH_TO), BUSY_PROCESS_PHASES)
+    for phase in BUSY_PROCESS_PHASES
+        c, tr, ps = fresh_controller()
+        try
+            drive_to!(ps, phase)
+            @test state(ps.fsm) == phase
+            tr.last_activity = time() - 10_000.0
+            handle!(c, HeartbeatMsg())
+            @test state(tr.fsm) == TestRunCreated
+            @test !tr.stall_warned
+            # The clock is restarted, not merely skipped: when the operation ends the run
+            # gets the whole threshold again before anything calls it stalled.
+            @test time() - tr.last_activity < 1.0
+        finally
+            c.heartbeat_timer === nothing || close(c.heartbeat_timer)
+        end
+    end
+
+    # `ProcessStarting` is deliberately *not* exempt: a worker that launches and never
+    # connects is the hang the heartbeat exists to catch, and it looks exactly like this.
+    c, tr, ps = fresh_controller()
+    try
+        @test !(ProcessStarting in BUSY_PROCESS_PHASES)
+        transition!(ps.fsm, ProcessStarting)
+        tr.last_activity = time() - 21.0
+        handle!(c, HeartbeatMsg())
+        @test state(tr.fsm) == TestRunCancelled
+    finally
+        c.heartbeat_timer === nothing || close(c.heartbeat_timer)
+    end
+
+    # A process belonging to a *different* run does not shield this one.
+    c, tr, ps = fresh_controller()
+    try
+        drive_to!(ps, ProcessActivatingEnv)
+        ps.testrun_id = "some-other-run"
+        tr.last_activity = time() - 21.0
+        handle!(c, HeartbeatMsg())
+        @test state(tr.fsm) == TestRunCancelled
+    finally
+        c.heartbeat_timer === nothing || close(c.heartbeat_timer)
+    end
+end
+
+@testitem "The stall explanation says what the processes were doing" begin
+    using TestItemControllers: TestItemController, ControllerCallbacks, TestRunState,
+        TestEnvironment, TestItemDetail, TestRunItem, TestSetupDetail, HeartbeatMsg,
+        TestProcessState, ProcessEnv, ProcessStarting, handle!, transition!
+
+    # The first version of this message asserted a test process "most likely died or
+    # wedged", which was flatly wrong every time the heartbeat misfired. Whatever it
+    # concludes, it now has to show its working.
+    noop = (args...) -> nothing
+    messages = String[]
+    callbacks = ControllerCallbacks(;
+        on_testitem_started = noop, on_testitem_passed = noop, on_testitem_failed = noop,
+        on_testitem_errored = (run_id, item_id, env_id, msgs, duration, perf...) ->
+            push!(messages, msgs[1].message),
+        on_testitem_skipped = noop, on_append_output = noop, on_attach_debugger = noop,
+    )
+
+    env = TestEnvironment("env-1", "julia", String[], nothing,
+        Dict{String,Union{String,Nothing}}(), "Normal", "Pkg", "file:///pkg", nothing,
+        nothing, nothing, false)
+    item = TestItemDetail("item-1", "file:///pkg/test/a.jl", "item-1", "Pkg", "file:///pkg",
+        true, String[], 1, 1, "@test true", 1, 1)
+
+    c = TestItemController(callbacks; run_stall_seconds=10.0)
+    try
+        tr = TestRunState("run-1", [env], [item],
+            [TestRunItem("item-1", "env-1", nothing, :Info)], TestSetupDetail[], 1)
+        tr.remaining_work[("item-1", "env-1")] = TestRunItem("item-1", "env-1", nothing, :Info)
+        c.test_runs["run-1"] = tr
+
+        ps = TestProcessState("proc-1", ProcessEnv(env))
+        ps.testrun_id = "run-1"
+        transition!(ps.fsm, ProcessStarting)
+        c.test_processes["proc-1"] = ps
+
+        tr.last_activity = time() - 21.0
+        handle!(c, HeartbeatMsg())
+
+        @test length(messages) == 1
+        @test occursin("no worker was busy", messages[1])
+        @test occursin("proc-1", messages[1])
+        @test occursin("ProcessStarting", messages[1])
+    finally
+        c.heartbeat_timer === nothing || close(c.heartbeat_timer)
+    end
+end


### PR DESCRIPTION
Fixes the run-stall heartbeat from #91, which on a cold cache fails healthy runs mid-precompile.

## What happens today

[Run 32794123684 of ModelPredictiveControl.jl](https://github.com/davidanthoff/ModelPredictiveControl.jl/actions/runs/32794123684) — TIC 1.10.1, cold cache. The macOS-1.12 and Windows-1.12 legs errored **all 98 items**. Nothing was wrong with any of them; the workers were still precompiling, and the controller said so every two minutes:

```
Warning: Environment activation still pending
  package = "ModelPredictiveControl"   is_precompile = true   elapsed_seconds = 1080.0

Error: Test run has made no progress; failing its remaining items
  idle_seconds = 714.7   remaining_work = 98
  processes = [… seconds_since_message::Nothing …]
```

`seconds_since_message::Nothing` is the tell — no process had *ever* sent a message, because activation had not finished.

## Why

`_touch_run_activity!` stamps `tr.last_activity` only from reactor messages, and the activation round-trip is a single `@async` JSON-RPC request: between `TestProcessStatusChangedMsg(…, "Activating")` and `TestProcessActivatedMsg` nothing reaches the reactor. The reactor is silent for the whole precompile *by construction*.

Two comments in the same file contradict each other:

| | |
|---|---|
| activation, `:2582` | "`nothing` — the default — means an activation is allowed to take as long as it takes, which is the only honest default when it covers a precompilation" |
| heartbeat, `:395` | "fires only when nothing whatsoever is happening to a run that still has work — which never is" |

Activation is precisely where the second is false.

Not marginal, either. Every leg in that run activated for 660–1100 s against a 600 s kill line:

| leg | activation | outcome |
|---|---|---|
| macOS 1.12 | > 1080 s | **killed — 98 errored** |
| Windows 1.12 | > 1080 s | **killed — 98 errored** |
| macOS 1.10 | 737 s | warned, survived |
| ubuntu 1.12 | 683 s | warned, survived |
| Windows 1.10 | 675 s | survived |
| ubuntu 1.10 | 663 s | survived |

The survivors won a race — each process's status message restarts the clock, so whichever activates last gets the window. A second mode from the other end: `AppendOutputMsg` carries a `testrun_id`, so a *printing* item counts as activity but a **silent** one does not. The macOS-rc leg warned at `idle_seconds = 313.5, remaining_work = 1`.

## The fix

`_run_has_busy_process` treats a run as progressing while any of its processes is in a phase where the controller is waiting on a worker operation it already handed over — `ProcessRevising`, `ProcessWaitingForPrecompile`, `ProcessActivatingEnv`, `ProcessRunning`. Each either owns a deadline of its own (`activation_timeout_seconds`, the item timeout) or is deliberately unbounded. Being busy *restarts* the clock rather than skipping the tick, so a run gets the whole threshold again once the operation ends.

What is left for the heartbeat is `ProcessStarting` and the transient controller-side phases — exactly the hang #91 was written for. The default of 300 s is untouched; it can stay that short precisely because it no longer counts time in which a worker is busy.

The failure message also stops asserting that a process "most likely died or wedged" without evidence, and names each process and its phase instead.

## Tests

- a new test drives a process to each busy phase along a legal FSM path and checks the run survives 10 000 s of reactor silence, and that the clock was restarted;
- `ProcessStarting` is asserted *not* exempt, and a busy process belonging to a different run is asserted not to shield this one;
- the explanation test asserts the message names the process and its phase;
- the existing #91 end-to-end test — a worker launched with `-e "sleep(600)"` that never connects — still fails its run in ~27 s.

Full suite: 228/228.

## Follow-ups (separate PRs)

`run_stall_seconds` is not reachable from CI at all: not plumbed through TestItemRuns, TestItemApp or `julia-run-testitems`, so there was no way to raise or disable it while this was biting. That plumbing is julia-testitems/TestItemRuns.jl, julia-testitems/TestItemApp.jl, julia-actions/julia-run-testitems and julia-testitems/testitem-workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)