### PR TITLE
Document what projectUri actually contributes

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -123,7 +123,7 @@ The 11 states model the full lifecycle of a child Julia process:
 | `ProcessRevising` | Running `Revise.revise()` in the child process. |
 | `ProcessStarting` | Launching a new Julia child process. |
 | `ProcessWaitingForPrecompile` | Waiting for environment precompilation to finish. |
-| `ProcessActivatingEnv` | Activating the package environment in the child process. |
+| `ProcessActivatingEnv` | Building and activating the test environment in the child process. |
 | `ProcessConfiguringTestRun` | Sending test run configuration (setups, coverage settings). |
 | `ProcessReadyToRun` | Configured and ready to receive test items. |
 | `ProcessRunning` | Executing test items. |
@@ -155,7 +155,8 @@ TestRunCreated → TestRunWaitingForProcs → TestRunProcsAcquired → TestRunRu
 `ProcessEnv` is an internal struct that serves as the dictionary key for the
 process pool. It captures the subset of [`TestEnvironment`](@ref) fields that
 determine process identity: `project_uri`, `package_uri`, `package_name`,
-`juliaCmd`, `juliaArgs`, `juliaNumThreads`, `mode`, and `env`. Custom `hash`
+`juliaCmd`, `juliaArgs`, `juliaNumThreads`, `mode`, `env`, `check_bounds`, and
+`color`. Custom `hash`
 and `==` methods ensure that two environments with the same configuration
 share a pool slot.
 
@@ -219,6 +220,39 @@ A test run proceeds through these stages:
    coverage data is aggregated and the result is put into the run's
    `completion_channel`, which `execute_testrun()` is blocking on.
 
+### Environment activation
+
+Stage 3 above is the most involved step in the system, and none of it is visible
+from the `activateEnv` request. The child process receives only `packageName`,
+`packageUri` and an optional `projectUri`, and builds the environment itself:
+
+1. The **source environment** is `projectUri` when the controller supplied one,
+   and `packageUri` otherwise.
+2. That folder is **mirrored into a throwaway scratch environment** rather than
+   activated directly — `TestEnv.activate` runs `Pkg.instantiate` on whatever is
+   active, which would resolve a `Manifest.toml` into the user's folder. The
+   mirror is deliberately nameless and carries the package as an ordinary
+   path-tracked dependency; `testprocess/TestItemServer/src/scratch_env.jl`
+   explains why in its header comment. Preferences travel separately, through a
+   dedicated environment directory appended to `LOAD_PATH`, because
+   `TestEnv.activate` replaces the active project again in the next step.
+3. `TestEnv.activate(packageName)` then builds the **test environment** from the
+   package's test target — `<package>/test/Project.toml` if it exists, otherwise
+   the package's own `[deps]` plus `[targets].test` resolved through `[extras]`
+   and `[weakdeps]` — plus the package itself, and makes a temporary directory
+   of its own the active project.
+4. `Pkg.Operations.sandbox_preserve` prunes the mirrored manifest to that test
+   target's transitive closure and merges it in.
+
+So `projectUri` contributes **version pins, not dependencies**, which is the same
+thing `Pkg.test` does when run from a dev environment. The user-facing account of
+the selection rules that produce `packageUri`/`projectUri` in the first place
+lives at [julia-testitems.org/guide/environments](https://julia-testitems.org/guide/environments).
+
+The controller serializes this request across processes — one is nominated to
+activate while the others wait — so that the test environment's precompile caches
+are built exactly once. See `_activate_env!` in `testitemcontroller.jl`.
+
 ### Cancellation and timeouts
 
 - Each test run has a `CancellationTokenSource`. If the caller's token fires,
@@ -237,7 +271,7 @@ second JSONRPC layer defined in `TestItemServerProtocol` (in
 
 | Method | Description |
 |:-------|:------------|
-| `activateEnv` | Activate the package environment and load imports. |
+| `activateEnv` | Build and activate the test environment, and load imports. |
 | `testserver/revise` | Run `Revise.revise()` and report whether a restart is needed. |
 | `testserver/ConfigureTestRun` | Send test setups, coverage settings, and log level. |
 | `testserver/runTestItems` | Execute a batch of test items. |

--- a/docs/src/jsonrpc-api.md
+++ b/docs/src/jsonrpc-api.md
@@ -168,7 +168,7 @@ arrive twice while the other never resolves.
 | `id` | `String` | Process identifier. |
 | `packageName` | `String` | Package under test. |
 | `packageUri` | `String \| null` | File URI of the package root. |
-| `projectUri` | `String \| null` | File URI of the custom project, if any. |
+| `projectUri` | `String \| null` | File URI of the project supplying the manifest, or `null` for the package folder itself. |
 | `coverage` | `Boolean` | Whether coverage is enabled. |
 | `env` | `Object<String, String \| null>` | Environment variables. |
 
@@ -209,11 +209,12 @@ the [Julia API](@ref) section.
 | `juliaNumThreads` | `String \| null` | `JULIA_NUM_THREADS` value. |
 | `juliaEnv` | `Object<String, String \| null>` | Additional env vars. |
 | `mode` | `String` | `"Normal"`, `"Coverage"`, or `"Debug"`. |
-| `packageName` | `String` | |
-| `packageUri` | `String` | |
-| `projectUri` | `String \| null` | |
-| `envContentHash` | `String \| null` | |
+| `packageName` | `String` | Name of the package under test. Its test target defines the environment's dependencies. |
+| `packageUri` | `String` | File URI of the package root — the folder whose `Project.toml` carries `name`, `uuid` and `version`. |
+| `projectUri` | `String \| null` | File URI of the project whose `Manifest.toml` supplies the version pins, or `null` to use the package folder as the source environment. Pins only: its `[deps]` never become importable. Must be the package folder itself or a project whose manifest `dev`s the package. |
+| `envContentHash` | `String \| null` | Opaque hash of everything the environment is built from. A pooled process whose hash still matches is revised; one whose hash differs is restarted. |
 | `checkBounds` | `String \| null` | Value for the `--check-bounds` flag. |
+| `color` | `Boolean \| null` | Start the test process with `--color=yes`, so its output carries ANSI escape sequences. |
 
 ### `TestRunItem`
 

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -20,7 +20,7 @@ Describes a Julia process configuration for running test items.
 - `mode::String` — one of `"Normal"`, `"Coverage"`, or `"Debug"`.
 - `package_name::String` — name of the package under test.
 - `package_uri::String` — file URI of the package root.
-- `project_uri::Union{Nothing,String}` — file URI of a custom project (or `nothing` for the package default).
+- `project_uri::Union{Nothing,String}` — file URI of the project whose `Manifest.toml` supplies the version pins, or `nothing` to use the package folder itself as the source environment. It supplies pins only: its `[deps]` do not become importable, because the test environment is built from the package's test target (`<package>/test/Project.toml`, or the package's `[deps]` plus `[targets].test` resolved through `[extras]`/`[weakdeps]`), exactly as `Pkg.test` builds it.
 - `env_content_hash::Union{Nothing,String}` — opaque hash of the environment content, used to decide whether a pooled process can be reused without a restart.
 - `check_bounds::Union{Nothing,String}` — value for the test process's `--check-bounds` flag: `"auto"` (or `nothing`, the default) respects `@inbounds` annotations and lets the test process reuse the precompile caches of normal dev sessions; `"yes"` forces bounds checks everywhere (the `Pkg.test` behavior) at the cost of precompiling the whole environment into a separate cache slot on the first run.
 - `color::Bool` — run the test process with `--color=yes`, so that its output carries ANSI escapes. Off by default. The escapes are passed through on both streams — per-item output (`on_append_output`) and process-level output (`on_process_output`) alike — and it is up to the client to render or strip them for whatever view each one goes to.

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -740,7 +740,7 @@ function _run_testitem(endpoint, params::TestItemServerProtocol.RunTestItem, mod
                     testItemId = params.id,
                     messages = [
                         TestItemServerProtocol.TestMessage(
-                            "Unable to load the `Test` package. Please ensure that `Test` is listed as a test dependency in the Project.toml for the package.",
+                            "Unable to load the `Test` package. Please ensure that `Test` is listed as a test dependency of the package — in `test/Project.toml` if the package has one, otherwise in `[extras]` and the `test` entry of `[targets]` in its Project.toml.",
                             TestItemServerProtocol.Location(
                                 params.uri,
                                 TestItemServerProtocol.Position(params.line, 1)

--- a/testprocess/TestItemServer/src/scratch_env.jl
+++ b/testprocess/TestItemServer/src/scratch_env.jl
@@ -451,8 +451,10 @@ every write TestEnv performs then lands in the scratch directory or in TestEnv's
 own temporary directory, never in the user's folder.
 
 When the source environment has a manifest it is copied over (with relative
-paths made absolute), so the test environment resolves against exactly the
-versions the user has pinned. When it does not — or when the manifest is in a
+paths made absolute), so the test environment resolves against the versions the
+user has pinned — for the packages the test target actually reaches, which is
+all `TestEnv` keeps: `Pkg.Operations.sandbox_preserve` prunes the manifest to
+that target's closure. When it does not — or when the manifest is in a
 format this Julia cannot read and cannot be downgraded — there is nothing to
 preserve and TestEnv's `Pkg.instantiate` resolves one into the scratch directory.
 """


### PR DESCRIPTION
Doc audit prompted by #97, where a user put a `Project.toml` + `Manifest.toml` in `test/special/`, `dev`ed the package into it, added `Aqua`, and expected `using Aqua` to work in the test items under it.

The behaviour is correct — `projectUri` supplies **version pins**, and the test environment is built from the package's test target — but this repo never said so. `project_uri` was described as "a custom project" and nothing more, which reads as "a custom project supplies the dependencies".

## Changes

- `src/datatypes.jl` — `project_uri` now states that it supplies the manifest's version pins, that `nothing` means the package folder is the source, and that its `[deps]` do not become importable because the environment comes from the package's test target.
- `docs/src/jsonrpc-api.md` — same wording for `projectUri`; the `TestEnvironment` table had **empty description cells** for `packageName`, `packageUri`, `projectUri` and `envContentHash`, and was missing `color` (which is on the wire at `src/json_protocol.jl:22`).
- `docs/src/internals.md` — the process-state table and the wire-protocol table both said the child "activates the package environment". That is exactly what it does not do: it mirrors the source environment into a nameless scratch environment, and TestEnv then replaces the active project with a sandbox of its own. Also added an **Environment activation** section — stage 3 of the run lifecycle was a single clause, and `TestEnv` appeared in the manual once, as a name in the vendoring list.
- `docs/src/internals.md` — the `ProcessEnv` field list omitted `check_bounds` and `color`, both part of process identity per `src/testenvironment.jl:35-37`.
- `scratch_env.jl` — "resolves against exactly the versions the user has pinned" overstates it; `sandbox_preserve` prunes the manifest to the test target's closure, so pins outside it have no effect.
- `TestItemServer.jl` — the "Unable to load the `Test` package" message named only `Project.toml`, sending a user who has a `test/Project.toml` to the wrong file.

The user-facing explanation of the selection rules lives on the docs site; see julia-testitems/julia-testitems.github.io#9, which adds the nested-project section this links to.

## Checks

`julia --project=docs docs/make.jl` exits 0 with only the pre-existing "141 docstrings not included in the manual" warning. Suite is 229/229 — one run hit a transient depot-level `IOError: stat(...registries\$0HIR.pid.deleted): permission denied (EACCES)` during activation, unrelated to these changes, and passed on rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)