### PR TITLE
Release the array behind a type annotated global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The teardown that frees a test item's globals now also frees an array bound to a global declared with a type, `x::Vector{UInt8} = …`. Such a binding rejects `nothing`, so the assignment threw, was swallowed, and the array stayed reachable for the life of the test process — and test processes are pooled, so it was held across every later run on that worker too. An empty array of the same type is assigned instead. A `const` still cannot be released: from Julia 1.12 on the assignment is rejected and redeclaring with `const` frees nothing either, because the previous binding partition goes on holding the old value, so a test item that binds a large object should use a plain global. Ported from julia-testitems/TestItemRunner.jl#145.
 - `Logging` is now declared in the test target. `test/test_worker_lifecycle.jl` does `using Logging`, so `Pkg.test()` always ended in `ArgumentError: Package Logging not found in current path` — meaning the test item covering the slow-activation warning had never actually run.
 
 ### Added

--- a/test/test_memory_release.jl
+++ b/test/test_memory_release.jl
@@ -5,10 +5,14 @@
     # julia-testitems/TestItemRunner.jl#65 reports.
     #
     # The fixture's first item parks a `WeakRef` to a large array in `Main` — `Main` is not
-    # a test code module, so the teardown leaves the probe itself alone — and its second
-    # item collects and looks at what the reference still points at. They have to run in
-    # this order on the same process, so they are driven as two consecutive runs rather
-    # than as one run of two items.
+    # a test code module, so the teardown leaves the probes themselves alone — and its
+    # second item collects and looks at what the references still point at. They have to
+    # run in this order on the same process, so they are driven as two consecutive runs
+    # rather than as one run of two items.
+    #
+    # There is one probe per binding form: a plain global and a type annotated one, both of
+    # which have to be released, and a `const`, which cannot be from Julia 1.12 on. The
+    # verdict on all three is the second item passing or failing.
     using TestItemControllers: TestItemController, TestRunItem, execute_testrun, shutdown, ControllerCallbacks
     import UUIDs
 

--- a/testdata/MemoryPackage/test/memory_tests.jl
+++ b/testdata/MemoryPackage/test/memory_tests.jl
@@ -1,21 +1,34 @@
 # Probes for the module teardown that frees whatever a test item bound to a global.
 #
 # Every test item runs in a module of its own, and Julia cannot unload a module, so
-# without the teardown the array below stays reachable for the life of the test process
+# without the teardown the arrays below stay reachable for the life of the test process
 # (julia-testitems/TestItemRunner.jl#65).
+#
+# One probe per binding form the teardown has to deal with: a plain global and a type
+# annotated one, both of which have to be released, and a `const`, which cannot be from
+# Julia 1.12 on. If Julia ever makes that last one collectable this fixture fails, which
+# is the reminder to update the docstring of `release_module_globals!` and the user docs.
 #
 # The two items have to run in this order on the same test process, which is why the test
 # drives them as two consecutive test runs rather than as one run of two items: the
 # controller keeps its remaining work in a `Dict`, so the order within a single run is not
 # something a test can rely on.
 #
-# The probe lives in `Main` rather than in the item's own module precisely because `Main`
+# The probes live in `Main` rather than in the item's own module precisely because `Main`
 # is what the teardown does *not* touch.
 
 @testitem "memory probe: bind" begin
     leaked = zeros(UInt8, 8_000_000)
     Core.eval(Main, :(MEMORY_PROBE = $(WeakRef(leaked))))
     @test length(leaked) == 8_000_000
+
+    typed::Vector{UInt8} = zeros(UInt8, 8_000_000)
+    Core.eval(Main, :(MEMORY_PROBE_TYPED = $(WeakRef(typed))))
+    @test length(typed) == 8_000_000
+
+    const pinned = zeros(UInt8, 8_000_000)
+    Core.eval(Main, :(MEMORY_PROBE_CONST = $(WeakRef(pinned))))
+    @test length(pinned) == 8_000_000
 end
 
 @testitem "memory probe: check" begin
@@ -24,4 +37,11 @@ end
 
     @test isdefined(Main, :MEMORY_PROBE)
     @test Main.MEMORY_PROBE.value === nothing
+
+    # Released through the empty-array fallback, because `nothing` does not fit the
+    # declared type
+    @test Main.MEMORY_PROBE_TYPED.value === nothing
+
+    # Not released, and cannot be — see the note above
+    @test Main.MEMORY_PROBE_CONST.value !== nothing
 end

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -503,9 +503,21 @@ not have to.
 
 Left alone: `eval`, `include` and the module's own name, which the `module` expression
 created rather than the test item, and submodules, because a `@testmodule` reached through
-one is shared with other test items. Bindings that cannot take `nothing` — a `const` on
-Julia before 1.12, a typed global, a name brought in by `using` — are skipped as they come
-up, because there is nothing else to try for them.
+one is shared with other test items.
+
+A global declared with a type, `x::Vector{UInt8} = …`, rejects `nothing`. When such a
+binding holds an array — the case where the memory is worth having back — an empty array of
+the same type is assigned instead, which the declared type does accept.
+
+A name brought in by `using` is skipped: assigning to it throws and there is nothing else to
+try.
+
+A `const` cannot be released from Julia 1.12 on: the assignment is rejected, and redeclaring
+with `const` frees nothing either, because the previous `Core.BindingPartition` goes on
+holding the old value. Before 1.12 the assignment goes through for some values, printing
+`WARNING: redefinition of constant`, and throws for others, so it is not something to rely
+on there either. A test item should bind a large object to a plain global rather than to a
+`const`, or it stays alive for the rest of the test process.
 """
 function release_module_globals!(mod::Module)
     for name in names(mod; all=true)
@@ -514,11 +526,24 @@ function release_module_globals!(mod::Module)
         occursin('#', string(name)) && continue
         isdefined(mod, name) || continue
 
+        value = try
+            getfield(mod, name)
+        catch
+            continue
+        end
+
+        value isa Module && continue
+
         try
-            getfield(mod, name) isa Module && continue
             # `Core.eval` rather than `setglobal!`, which only exists from Julia 1.9 on
             Core.eval(mod, Expr(:(=), name, nothing))
         catch
+            value isa Array || continue
+
+            try
+                Core.eval(mod, Expr(:(=), name, similar(value, ntuple(_ -> 0, ndims(value)))))
+            catch
+            end
         end
     end
 


### PR DESCRIPTION
Ports julia-testitems/TestItemRunner.jl#145 — `TestItemServer.release_module_globals!` was
byte-identical to the pre-fix TestItemRunner version, docstring included.

`release_module_globals!` sets every global of a test item's module to `nothing` when the
item finishes, because Julia cannot unload the module. A global declared with a type does
not accept `nothing`:

```julia
@testitem "…" begin
    buffer::Vector{UInt8} = zeros(UInt8, 100_000_000)
    @test length(buffer) == 100_000_000
end
```

The assignment throws on `convert`, the bare `catch` swallows it, and the array stays
reachable. This matters more here than in TestItemRunner: test processes are pooled, so the
array is held not just for the rest of that run but for every later run on that worker.
Neither existing mitigation helps — `gc_between_testitems` is off by default for a
single-process run and `GC.gc(true)` cannot free what a live module global points at, and
`memory_threshold` is off by default and recycles the whole process when it does fire.

When the binding holds an array — the case where the memory is worth having back — the
teardown now falls back to assigning an empty array of the same type. Everything else is
skipped as before, and nothing needs a `VERSION` guard: `isa Array`, `similar` with a `Dims`
tuple and `ntuple` all work on Julia 1.0, which the test process still supports.

Measured on the identical function in TestItemRunner, ten test items binding 100 MB each
behind such a global:

| | before | after |
|---|---|---|
| Julia 1.12.7 | 417 MB → 1303 MB | flat |
| Julia 1.13.0-rc3 | 344 MB → 1203 MB | flat |

The docstring also had the `const` case backwards — it said a `const` is only skipped
"on Julia before 1.12". In fact from 1.12 on a `const` cannot be released at all: the
assignment is rejected, and redeclaring with `const` frees nothing either, because the
previous `Core.BindingPartition` goes on holding the old value (verified with
`gc_live_bytes`). Before 1.12 the plain assignment goes through for some values, with a
`WARNING: redefinition of constant`, and throws for others.

`testdata/MemoryPackage` probed a single plain global — the case that already worked — so it
now probes all three binding forms, keeping the two-item / two-run shape that
`test/test_memory_release.jl` drives. That test fails with the extended fixture and the old
teardown, and passes with this change.

Full suite green on the host Julia: 1143/1143 in 18m55s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
