### PR TITLE
Fix output capture breaking on multi-byte characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Captured output containing multi-byte characters no longer kills the output reader ([#101](https://github.com/julia-testitems/TestItemControllers.jl/issues/101)). The demultiplexer that attributes a test process's output to test items mixed character counts with byte indices, so a `✔` next to the end of a frame header raised a `StringIndexError`, after which the process's output was never forwarded again. It now works on bytes throughout, holds back a multi-byte character that a pipe read split in two so every forwarded chunk is valid UTF-8, and no longer drops the output left in its buffer when the process exits. The frame header a test process writes now ends in `\x1f` rather than `"` and goes out as a single write, so a test item name containing a double quote — or output another task writes at the same moment — no longer truncates the id.
 - `Logging` is now declared in the test target. `test/test_worker_lifecycle.jl` does `using Logging`, so `Pkg.test()` always ended in `ArgumentError: Package Logging not found in current path` — meaning the test item covering the slow-activation warning had never actually run.
 
 ### Added

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -187,12 +187,29 @@ JSONRPC connection.
 
 ### Output demultiplexing
 
-Child processes interleave output from multiple test items on a single
-`stdout` stream. The controller uses sentinel markers
-(`\x1f3805a0ad41b54562a46add40be31ca27` and
-`\x1f4031af828c3d406ca42e25628bb0aa77`) embedded in the output to associate
-each chunk with the correct test item. The IO task in `testprocess.jl`
-parses these markers and dispatches `AppendOutputMsg` messages to the reactor.
+A child process's `stdout` and `stderr` both go to one pipe, which carries the
+process's own output as well as that of whichever test item is running. The
+test server frames each item's output so the controller can attribute it:
+
+```
+\x1f3805a0ad41b54562a46add40be31ca27<test item id>\x1f  …output…  \x1f4031af828c3d406ca42e25628bb0aa77
+```
+
+`\x1f` (ASCII unit separator) opens both markers and terminates the id. It is
+a control character that never appears in an id or in ordinary output, which a
+`"` — the previous terminator — does not guarantee. The server writes the
+whole frame header as a single string, so output from another task cannot land
+between the marker and the id.
+
+`OutputDemuxer` in `testprocess.jl` parses the stream on the IO task. It works
+on bytes rather than characters: the markers are ASCII, and cutting the id out
+by byte offset means a multi-byte character anywhere in the stream cannot
+produce an invalid string index. A chunk read from the pipe can end part way
+through a marker, an id or a multi-byte character; whatever cannot be
+classified yet is held for the next chunk, so every forwarded string is valid
+UTF-8 when the process's output is. Runs of output are dispatched to the
+reactor as `TestProcessOutputMsg` (the whole stream) and `AppendOutputMsg`
+(per test item).
 
 ## Test run lifecycle
 

--- a/src/testprocess.jl
+++ b/src/testprocess.jl
@@ -79,6 +79,171 @@ function _truncate_for_log(s::AbstractString; max_bytes::Int=8192)
     return SubString(s, 1, i) * "... ($(ncodeunits(s) - i) bytes truncated)"
 end
 
+# ---------------------------------------------------------------------------
+# Output demultiplexing
+#
+# A test process shares one pipe (its stdout and stderr both point at it) between the
+# process's own output and the output of whichever test item is running. The test server
+# frames each item's output so the two can be told apart again:
+#
+#     \x1f<begin uuid><test item id>\x1f   …item output…   \x1f<end uuid>
+#
+# The framing is duplicated in `testprocess/TestItemServer/src/TestItemServer.jl`, which
+# writes it; keep the two in sync. `\x1f` (ASCII unit separator) starts both markers and
+# terminates the id — a control character that never occurs in an id or in ordinary
+# output. The id used to be terminated by `"` instead, which is common in output; with the
+# marker and the id going out as separate writes, another task's output could land in
+# between and its first `"` was taken for the end of the id (#101).
+#
+# `OutputDemuxer` parses the stream. It works on *bytes* throughout: the markers are ASCII,
+# so byte comparison is exact, and the id is cut out by byte offsets, so a multi-byte
+# character anywhere in the stream cannot produce an invalid string index — the previous
+# parser mixed `length` (characters) with byte indices and threw a `StringIndexError` on a
+# `✔` (#101), after which the process's output was never forwarded again. `feed!` never
+# throws on any byte sequence.
+#
+# A chunk read from the pipe can end anywhere: part way through a marker, through the id,
+# or through a multi-byte character. Whatever cannot be classified yet stays in the buffer
+# for the next chunk, including an incomplete trailing UTF-8 sequence, so every string
+# handed out is valid UTF-8 when the process's output is.
+
+const OUTPUT_BEGIN_MARKER = "\x1f3805a0ad41b54562a46add40be31ca27"
+const OUTPUT_END_MARKER = "\x1f4031af828c3d406ca42e25628bb0aa77"
+const OUTPUT_FRAME_BYTE = 0x1f
+
+const _OUTPUT_BEGIN_MARKER_BYTES = Vector{UInt8}(codeunits(OUTPUT_BEGIN_MARKER))
+const _OUTPUT_END_MARKER_BYTES = Vector{UInt8}(codeunits(OUTPUT_END_MARKER))
+
+mutable struct OutputDemuxer
+    # Bytes not yet handed out: a possible marker prefix, an id without its terminator
+    # yet, or an incomplete UTF-8 sequence.
+    buffer::Vector{UInt8}
+    # The item whose output frame is open, or `nothing` between frames.
+    current_testitem_id::Union{Nothing,String}
+end
+
+OutputDemuxer() = OutputDemuxer(UInt8[], nothing)
+
+# Output runs in stream order, each attributed to the test item whose frame it fell in
+# (`nothing` for the process's own output between frames).
+const OutputRuns = Vector{Pair{Union{Nothing,String},String}}
+
+# Whether `marker` occurs at `buf[i]`: `:full` if it does, `:partial` if `buf[i:n]` runs out
+# while still agreeing with it, `:none` otherwise.
+function _match_marker(buf::Vector{UInt8}, i::Int, n::Int, marker::Vector{UInt8})
+    for j in eachindex(marker)
+        k = i + j - 1
+        k > n && return :partial
+        buf[k] == marker[j] || return :none
+    end
+    return :full
+end
+
+# Length of an incomplete UTF-8 sequence at the end of `buf[lo:hi]`: a lead byte followed by
+# fewer continuation bytes than it announces. Anything else — complete sequences, ASCII,
+# stray continuation bytes, bytes that cannot start a sequence — is 0, so malformed output
+# passes through unchanged rather than being held forever.
+function _incomplete_utf8_tail(buf::Vector{UInt8}, lo::Int, hi::Int)
+    k = hi
+    while k >= lo && hi - k < 3 && (buf[k] & 0xC0) == 0x80
+        k -= 1
+    end
+    k < lo && return 0
+    lead = buf[k]
+    need = lead >= 0xF8 ? 0 :
+           lead >= 0xF0 ? 4 :
+           lead >= 0xE0 ? 3 :
+           lead >= 0xC0 ? 2 : 0
+    have = hi - k + 1
+    return need > have ? have : 0
+end
+
+function _push_run!(runs::OutputRuns, id::Union{Nothing,String}, buf::Vector{UInt8}, lo::Int, hi::Int)
+    lo > hi && return
+    text = String(buf[lo:hi])
+    if !isempty(runs) && runs[end].first == id
+        runs[end] = id => runs[end].second * text
+    else
+        push!(runs, id => text)
+    end
+    return
+end
+
+"""
+    feed!(d::OutputDemuxer, data) -> OutputRuns
+
+Consume the next chunk of a test process's output and return the output that can be
+attributed so far, in order, each run paired with the id of the test item it belongs to
+(`nothing` outside any item's frame). Bytes that might be the start of a marker, an id
+still missing its terminator, or an incomplete UTF-8 character are kept for the next call.
+"""
+function feed!(d::OutputDemuxer, data::AbstractVector{UInt8})
+    append!(d.buffer, data)
+    buf = d.buffer
+    n = length(buf)
+    runs = OutputRuns()
+
+    text_start = 1      # first byte of the text run not yet handed out
+    keep_from = n + 1   # first byte that stays in the buffer
+    i = 1
+    while i <= n
+        if buf[i] != OUTPUT_FRAME_BYTE
+            i += 1
+            continue
+        end
+
+        in_frame = d.current_testitem_id !== nothing
+        marker = in_frame ? _OUTPUT_END_MARKER_BYTES : _OUTPUT_BEGIN_MARKER_BYTES
+        m = _match_marker(buf, i, n, marker)
+        if m == :none
+            # A lone frame byte in the output: not ours, pass it through.
+            i += 1
+        elseif m == :partial
+            keep_from = i
+            break
+        elseif in_frame
+            _push_run!(runs, d.current_testitem_id, buf, text_start, i - 1)
+            d.current_testitem_id = nothing
+            i += length(marker)
+            text_start = i
+        else
+            id_start = i + length(marker)
+            id_end = findnext(==(OUTPUT_FRAME_BYTE), buf, id_start)
+            if id_end === nothing
+                keep_from = i
+                break
+            end
+            _push_run!(runs, nothing, buf, text_start, i - 1)
+            d.current_testitem_id = String(buf[id_start:id_end-1])
+            i = id_end + 1
+            text_start = i
+        end
+    end
+
+    if keep_from > n
+        # No marker in progress: hand out the trailing text, minus a character that is
+        # still arriving.
+        keep_from = n + 1 - _incomplete_utf8_tail(buf, text_start, n)
+    end
+    _push_run!(runs, d.current_testitem_id, buf, text_start, keep_from - 1)
+    deleteat!(buf, 1:keep_from-1)
+
+    return runs
+end
+
+"""
+    flush!(d::OutputDemuxer) -> OutputRuns
+
+Hand out whatever `feed!` was still holding, verbatim. For the end of the stream, where
+nothing more is coming to complete a marker or a character.
+"""
+function flush!(d::OutputDemuxer)
+    runs = OutputRuns()
+    _push_run!(runs, d.current_testitem_id, d.buffer, 1, length(d.buffer))
+    empty!(d.buffer)
+    return runs
+end
+
 # Number of interactive threads reserved in a test process. The main task — and therefore
 # the runner loop and every test item — occupies the first; the hang watchdog gets the
 # second, which is what lets it run while an item has the main thread wedged. Only the
@@ -268,116 +433,50 @@ function start(testprocess_id, reactor_channel, ps::TestProcessState, env::Proce
                 raw_output_lock = ReentrantLock()
 
                 @async try
-                    begin_marker = "\x1f3805a0ad41b54562a46add40be31ca27"
-                    end_marker = "\x1f4031af828c3d406ca42e25628bb0aa77"
-                    buffer = ""
-                    current_output_testitem_id = nothing
-                    while !eof(pipe_out)
-                        data = readavailable(pipe_out, token)
-                        ps.last_output_at = time()
-                        data_as_string = String(data)
-
-                        # Capture raw output for crash diagnostics
-                        lock(raw_output_lock) do
-                            push!(raw_output_chunks, data_as_string)
-                        end
-
-                        buffer *= data_as_string
-
-                        output_for_test_proc = IOBuffer()
-                        output_for_test_items = Pair{Union{Nothing,String},IOBuffer}[]
-
-                        i = 1
-                        while i<=length(buffer)
-                            might_be_begin_marker = false
-                            might_be_end_marker = false
-
-                            if current_output_testitem_id === nothing
-                                j = 1
-                                might_be_begin_marker = true
-                                while i + j - 1<=length(buffer) && j <= length(begin_marker)
-                                    if buffer[i + j - 1] != begin_marker[j] || nextind(buffer, i + j - 1) != i + j
-                                        might_be_begin_marker = false
-                                        break
-                                    end
-                                    j += 1
-                                end
-                                is_begin_marker = might_be_begin_marker && length(buffer) - i + 1 >= length(begin_marker)
-
-                                if is_begin_marker
-                                    ti_id_end_index = findfirst("\"", SubString(buffer, i))
-                                    if ti_id_end_index === nothing
-                                        break
-                                    else
-                                        current_output_testitem_id = SubString(buffer, i + length(begin_marker), i + ti_id_end_index.start - 2)
-                                        i = nextind(buffer, i + ti_id_end_index.start - 1)
-                                    end
-                                elseif might_be_begin_marker
-                                    break
-                                end
-                            else
-                                j = 1
-                                might_be_end_marker = true
-                                while i + j - 1<=length(buffer) && j <= length(end_marker)
-                                    if buffer[i + j - 1] != end_marker[j] || nextind(buffer, i + j - 1) != i + j
-                                        might_be_end_marker = false
-                                        break
-                                    end
-                                    j += 1
-                                end
-                                is_end_marker = might_be_end_marker && length(buffer) - i + 1 >= length(end_marker)
-
-                                if is_end_marker
-                                    current_output_testitem_id = nothing
-                                    i = i + length(end_marker)
-                                elseif might_be_end_marker
-                                    break
-                                end
-                            end
-
-                            if !might_be_begin_marker && !might_be_end_marker
-                                print(output_for_test_proc, buffer[i])
-
-                                if length(output_for_test_items) == 0 || output_for_test_items[end].first != current_output_testitem_id
-                                    push!(output_for_test_items, current_output_testitem_id => IOBuffer())
-                                end
-
-                                output_for_ti = output_for_test_items[end].second
-                                if !CancellationTokens.is_cancellation_requested(token)
-                                    print(output_for_ti, buffer[i])
-                                end
-
-                                i = nextind(buffer, i)
-                            end
-                        end
-
-                        buffer = buffer[i:end]
-
-                        output_for_test_proc_as_string = String(take!(output_for_test_proc))
-
-                        if length(output_for_test_proc_as_string) > 0
-                            @debug "Forwarding process output chunk" testprocess_id output=_truncate_for_log(output_for_test_proc_as_string)
+                    # Post one chunk of demultiplexed output to the reactor: the whole of it
+                    # as the process's output, and each run as its test item's.
+                    function forward_output(runs)
+                        process_output = join(run.second for run in runs)
+                        if !isempty(process_output)
+                            @debug "Forwarding process output chunk" testprocess_id output=_truncate_for_log(process_output)
                             put!(
                                 reactor_channel,
-                                TestProcessOutputMsg(testprocess_id, output_for_test_proc_as_string)
+                                TestProcessOutputMsg(testprocess_id, process_output)
                             )
                         end
 
-                        for (k,v) in output_for_test_items
-                            output_for_ti_as_string = String(take!(v))
+                        # Item output stops being attributed once the run is cancelled; the
+                        # process's own output above is still forwarded.
+                        CancellationTokens.is_cancellation_requested(token) && return
 
-                            if length(output_for_ti_as_string) > 0
-                                testrun_id = ps.testrun_id
-                                if testrun_id !== nothing
-                                    @debug "Forwarding test item output chunk" testprocess_id testitem_id=something(k, missing) output=_truncate_for_log(output_for_ti_as_string)
-                                    put!(
-                                        reactor_channel,
-                                        AppendOutputMsg(testrun_id, testprocess_id, k, replace(output_for_ti_as_string, "\n"=>"\r\n"))
-                                    )
-                                end
+                        for (k, v) in runs
+                            isempty(v) && continue
+                            testrun_id = ps.testrun_id
+                            if testrun_id !== nothing
+                                @debug "Forwarding test item output chunk" testprocess_id testitem_id=something(k, missing) output=_truncate_for_log(v)
+                                put!(
+                                    reactor_channel,
+                                    AppendOutputMsg(testrun_id, testprocess_id, k, replace(v, "\n"=>"\r\n"))
+                                )
                             end
                         end
                     end
+
+                    demux = OutputDemuxer()
+                    while !eof(pipe_out)
+                        data = readavailable(pipe_out, token)
+                        ps.last_output_at = time()
+
+                        # Capture raw output for crash diagnostics
+                        lock(raw_output_lock) do
+                            push!(raw_output_chunks, String(copy(data)))
+                        end
+
+                        forward_output(feed!(demux, data))
+                    end
+                    # The stream is over: whatever was being held back for a marker or a
+                    # character that never completed is output after all.
+                    forward_output(flush!(demux))
                 catch err
                     if err isa CancellationTokens.OperationCanceledException
                         @debug "Output reading cancelled by token" testprocess_id

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -77,3 +77,35 @@
     @test occursin("hello from output test", combined_output)
     @test occursin("second line of output", combined_output)
 end
+
+@testitem "Output capture survives multi-byte characters (#101)" setup=[TestHelpers] begin
+    # A `✔` in the captured output raised a `StringIndexError` on the output-reading task,
+    # after which nothing the process printed was forwarded any more. The item's name puts
+    # one at the end of its id as well, which is where the report's crash was.
+    pkg_path = joinpath(TestHelpers.TESTDATA_DIR, "BasicPackage")
+    discovered = TestHelpers.discover_test_items(pkg_path)
+
+    items = filter(i -> i.label == "unicode output ✔", discovered.items)
+    @test length(items) == 1
+    item = only(items)
+    @test endswith(item.id, "✔")
+
+    result = TestHelpers.run_testrun(items, discovered.setups; timeout=300, TestHelpers._env_kwargs(discovered)...)
+
+    @test length(filter(e -> e.event == :passed, result.events)) == 1
+
+    # Attributed to the right item, complete, and valid UTF-8 — the 100,000-character line
+    # is read from the pipe in several chunks, so the reader had to reassemble a character
+    # split between two of them.
+    item_output = get(result.outputs, item.id, "")
+    @test isvalid(item_output)
+    @test occursin("✔ check \"quoted\" ✓", item_output)
+    @test occursin("✔"^100_000, item_output)
+
+    # None of it leaked into the process's own output (the launch and precompile chatter
+    # that precedes the first frame).
+    process_output = get(result.outputs, nothing, "")
+    @test isvalid(process_output)
+    @test !occursin("✔ check", process_output)
+    @test !occursin("✔✔", process_output)
+end

--- a/test/test_output_demux.jl
+++ b/test/test_output_demux.jl
@@ -1,0 +1,210 @@
+@testmodule DemuxHelpers begin
+    using TestItemControllers: OutputDemuxer, feed!, flush!, OUTPUT_BEGIN_MARKER, OUTPUT_END_MARKER
+
+    export Run, frame, demux, demux_chunked, merged
+
+    const Run = Pair{Union{Nothing,String},String}
+
+    # The frame the test server writes around one item's output.
+    frame(id, body) = string(OUTPUT_BEGIN_MARKER, id, '\x1f', body, OUTPUT_END_MARKER)
+
+    # Adjacent runs for the same item joined, empty ones dropped — what a consumer sees
+    # once it has appended everything, regardless of where the chunk boundaries fell.
+    function merged(runs)
+        out = Run[]
+        for (id, text) in runs
+            isempty(text) && continue
+            if !isempty(out) && out[end].first == id
+                out[end] = id => out[end].second * text
+            else
+                push!(out, id => text)
+            end
+        end
+        return out
+    end
+
+    # Feed `stream` in chunks of the given byte sizes (the last one absorbs the remainder),
+    # flush, and return the merged runs.
+    function demux_chunked(stream::AbstractString, sizes)
+        d = OutputDemuxer()
+        bytes = Vector{UInt8}(codeunits(stream))
+        runs = Run[]
+        pos = 1
+        for size in sizes
+            pos > length(bytes) && break
+            hi = min(pos + size - 1, length(bytes))
+            append!(runs, feed!(d, bytes[pos:hi]))
+            pos = hi + 1
+        end
+        pos <= length(bytes) && append!(runs, feed!(d, bytes[pos:end]))
+        append!(runs, flush!(d))
+        return merged(runs)
+    end
+
+    demux(stream::AbstractString) = demux_chunked(stream, [ncodeunits(stream)])
+end
+
+@testitem "Output demuxer attributes framed output to its test item" setup=[DemuxHelpers] begin
+    stream = "booting\n" * frame("A", "hello\n") * "between\n" * frame("B", "world\n") * "done\n"
+
+    @test demux(stream) == Run[
+        nothing => "booting\n",
+        "A" => "hello\n",
+        nothing => "between\n",
+        "B" => "world\n",
+        nothing => "done\n",
+    ]
+
+    # Back-to-back frames, and frames with nothing in them.
+    @test demux(frame("A", "") * frame("B", "x")) == Run["B" => "x"]
+    @test demux("") == Run[]
+end
+
+@testitem "Output demuxer survives multi-byte characters (#101)" setup=[DemuxHelpers] begin
+    # The report: a `✔` right before a `"` in the output, and an item id ending in one.
+    id = "Genie@1234abcd/test/tests_markdown_rendering.jl::String markdown rendering ✔"
+    stream = "✔\"quoted\" ✓\n" * frame(id, "✔ passed ✔\"\n") * "✔ done\n"
+
+    runs = demux(stream)
+    @test runs == Run[
+        nothing => "✔\"quoted\" ✓\n",
+        id => "✔ passed ✔\"\n",
+        nothing => "✔ done\n",
+    ]
+    @test all(isvalid(r.second) for r in runs)
+end
+
+@testitem "Output demuxer keeps an id with quotes and multi-byte characters intact" setup=[DemuxHelpers] begin
+    id = "Pkg@1234abcd/test/x.jl::handles \"quoted\" input ✔"
+    @test demux(frame(id, "out\n")) == Run[id => "out\n"]
+end
+
+@testitem "Output demuxer is independent of where chunks split" setup=[DemuxHelpers] begin
+    using Random
+
+    id = "Pkg@1234abcd/test/x.jl::name ✔"
+    stream = "✔ start\n" * frame(id, "✔✓ output ✔\n") * "mid ✓\n" * frame("B", "λ") * "✔ end"
+    expected = demux(stream)
+    @test length(expected) == 5
+
+    # One byte at a time, and every fixed chunk size that puts a boundary inside a marker,
+    # an id, or a character somewhere.
+    for size in 1:40
+        @test demux_chunked(stream, fill(size, ncodeunits(stream))) == expected
+    end
+
+    rng = MersenneTwister(101)
+    for _ in 1:200
+        sizes = rand(rng, 1:12, ncodeunits(stream))
+        @test demux_chunked(stream, sizes) == expected
+    end
+end
+
+@testitem "Output demuxer hands out valid UTF-8 whatever the chunking" setup=[DemuxHelpers] begin
+    using TestItemControllers: OutputDemuxer, feed!, flush!
+
+    stream = "✔ a\n" * frame("A ✔", "✔✔✔ λ\n") * "✓"
+    bytes = Vector{UInt8}(codeunits(stream))
+
+    d = OutputDemuxer()
+    for b in bytes
+        for (_, text) in feed!(d, [b])
+            @test isvalid(text)
+        end
+    end
+    @test isempty(flush!(d))
+end
+
+@testitem "Output demuxer holds back an incomplete character until it completes" setup=[DemuxHelpers] begin
+    using TestItemControllers: OutputDemuxer, feed!, flush!
+
+    check = Vector{UInt8}(codeunits("✔"))
+    @test length(check) == 3
+
+    d = OutputDemuxer()
+    @test merged(feed!(d, check[1:1])) == Run[]
+    @test merged(feed!(d, check[2:2])) == Run[]
+    @test merged(feed!(d, check[3:3])) == Run[nothing => "✔"]
+
+    # A four-byte character, split after two bytes.
+    emoji = Vector{UInt8}(codeunits("🎉"))
+    @test merged(feed!(d, vcat(codeunits("x"), emoji[1:2]))) == Run[nothing => "x"]
+    @test merged(feed!(d, emoji[3:4])) == Run[nothing => "🎉"]
+
+    # Whatever never completes is still output when the stream ends.
+    @test merged(feed!(d, check[1:2])) == Run[]
+    tail = flush!(d)
+    @test length(tail) == 1
+    @test codeunits(tail[1].second) == check[1:2]
+    @test isempty(flush!(d))
+
+    # Bytes that cannot be the start of a character are never held.
+    @test merged(feed!(d, [0x80])) == Run[nothing => String([0x80])]
+    @test merged(feed!(d, [0xff])) == Run[nothing => String([0xff])]
+end
+
+@testitem "Output demuxer holds a partial frame header until it completes" setup=[DemuxHelpers] begin
+    using TestItemControllers: OutputDemuxer, feed!, flush!, OUTPUT_BEGIN_MARKER
+
+    d = OutputDemuxer()
+    @test merged(feed!(d, codeunits("a\n"))) == Run[nothing => "a\n"]
+    # Half a marker: could still become one.
+    @test merged(feed!(d, codeunits(OUTPUT_BEGIN_MARKER[1:10]))) == Run[]
+    # The rest of the marker and part of the id, still no terminator.
+    @test merged(feed!(d, codeunits(OUTPUT_BEGIN_MARKER[11:end] * "some id ✔"))) == Run[]
+    @test merged(feed!(d, codeunits("\x1fout"))) == Run["some id ✔" => "out"]
+    @test merged(flush!(d)) == Run[]
+end
+
+@testitem "Output demuxer passes frame bytes that are not markers through" setup=[DemuxHelpers] begin
+    using TestItemControllers: OUTPUT_BEGIN_MARKER, OUTPUT_END_MARKER
+
+    # A stray unit separator, and a prefix of a marker that turns out not to be one.
+    @test demux("a\x1fb") == Run[nothing => "a\x1fb"]
+    @test demux("a" * OUTPUT_BEGIN_MARKER[1:8] * "zzz") == Run[nothing => "a" * OUTPUT_BEGIN_MARKER[1:8] * "zzz"]
+
+    # Inside a frame only the end marker counts; an end marker outside a frame is text.
+    @test demux(frame("A", "x" * OUTPUT_BEGIN_MARKER * "y")) == Run["A" => "x" * OUTPUT_BEGIN_MARKER * "y"]
+    @test demux("p" * OUTPUT_END_MARKER * "q") == Run[nothing => "p" * OUTPUT_END_MARKER * "q"]
+
+    # A marker cut off by the end of the stream is output after all.
+    @test demux("a" * OUTPUT_BEGIN_MARKER[1:20]) == Run[nothing => "a" * OUTPUT_BEGIN_MARKER[1:20]]
+    @test demux(frame("A", "x") * OUTPUT_BEGIN_MARKER * "unterminated id") ==
+        Run["A" => "x", nothing => OUTPUT_BEGIN_MARKER * "unterminated id"]
+end
+
+@testitem "Output demuxer never throws and loses no bytes on arbitrary input" setup=[DemuxHelpers] begin
+    using Random
+    using TestItemControllers: OutputDemuxer, feed!, flush!
+
+    rng = MersenneTwister(7)
+    for _ in 1:300
+        bytes = rand(rng, UInt8, rand(rng, 0:400))
+        # Random bytes never spell a 33-byte marker, so every byte must come back out, in
+        # order, however the chunks fall.
+        d = OutputDemuxer()
+        out = UInt8[]
+        pos = 1
+        while pos <= length(bytes)
+            hi = min(pos + rand(rng, 0:20), length(bytes))
+            for (_, text) in feed!(d, bytes[pos:hi])
+                append!(out, codeunits(text))
+            end
+            pos = hi + 1
+        end
+        for (_, text) in flush!(d)
+            append!(out, codeunits(text))
+        end
+        @test out == bytes
+    end
+
+    # The same for streams that do contain frames, with random text around and inside them.
+    for _ in 1:100
+        text() = String(rand(rng, UInt8, rand(rng, 0:30)))
+        stream = text() * frame(text(), text()) * text()
+        d = OutputDemuxer()
+        runs = feed!(d, Vector{UInt8}(codeunits(stream)))
+        append!(runs, flush!(d))
+        @test runs isa Vector
+    end
+end

--- a/testdata/BasicPackage/test/basic_tests.jl
+++ b/testdata/BasicPackage/test/basic_tests.jl
@@ -76,3 +76,11 @@ end
 @testitem "abort crash" begin
     ccall(:abort, Cvoid, ())
 end
+
+@testitem "unicode output ✔" begin
+    println("✔ check \"quoted\" ✓")
+    # Long enough that the controller reads it from the pipe in several chunks, so a
+    # chunk boundary falls inside a multi-byte character.
+    println("✔" ^ 100_000)
+    @test true
+end

--- a/testprocess/TestItemServer/src/TestItemServer.jl
+++ b/testprocess/TestItemServer/src/TestItemServer.jl
@@ -1373,7 +1373,11 @@ function runner_loop(state::TestProcessState)
                 saved_load_path = copy(LOAD_PATH)
                 saved_cwd = pwd()
 
-                print(stderr, "\x1f3805a0ad41b54562a46add40be31ca27", "$(current_testitem.id)\"", "")
+                # Opens this item's output frame; the controller's `OutputDemuxer` in
+                # `src/testprocess.jl` parses it, and the two must agree. One string, hence
+                # one write: sent as separate pieces, output another task writes in between
+                # lands inside the frame header and corrupts the id.
+                print(stderr, string("\x1f3805a0ad41b54562a46add40be31ca27", current_testitem.id, '\x1f'))
                 flush(stderr)
                 arm_watchdog!(current_testitem.id, current_testitem.timeoutMs)
                 ret = try


### PR DESCRIPTION
Fixes #101.

## What was wrong

The output demultiplexer in `src/testprocess.jl` — the loop that attributes a test process's output to test items by the `\x1f…` frame markers — mixed **character counts** (`length(buffer)`) with **byte indices** (`buffer[i]`, `SubString(buffer, i, j)`). Three consequences:

- The test item id was sliced as "up to one byte before the `"`", which is not a character boundary when the byte before the quote is the tail of a multi-byte character. That is the `StringIndexError` in the report (`[119]=>'✔', [122]=>'"'`). Once the reading task dies, nothing the process prints is forwarded for the rest of its life.
- With multi-byte text in the buffer the loop stopped before the end of the buffer, delaying output by a chunk and silently dropping the tail at process exit.
- A pipe read that split a multi-byte character forwarded two malformed fragments.

The `"` terminator was also fragile: the server wrote the marker and the id as separate `print` arguments, i.e. separate libuv writes with a yield between them, so output from another task (or from `stdout`, which is a different fd into the same pipe) could land inside the frame header. Genie's own `✔ "…"` logging is the likely origin of the `✔"` in the report. A test item whose *name* contains a `"` was truncated the same way.

## What changed

- **`src/testprocess.jl`**: the parser is now a small, pure `OutputDemuxer` (`feed!`/`flush!`) that works on bytes throughout. It holds back a partial marker, an id without its terminator, and an incomplete trailing UTF-8 sequence for the next chunk, so every forwarded string is valid UTF-8 when the process's output is, and it never throws on any byte sequence. The `@async` reader is now a thin loop over it, and forwards the buffered tail at EOF.
- **`testprocess/TestItemServer/src/TestItemServer.jl`**: the frame header is written as one string — `marker * id * '\x1f'` — so it goes out in a single write, and the id terminator is `\x1f` (a control character that cannot appear in an id or in ordinary output) instead of `"`. Server and parser ship together via the `[sources]` path, so the wire format changes in lockstep.
- **`docs/src/internals.md`**: describes the frame and the parsing rules.
- **Tests**: `test/test_output_demux.jl` unit-tests the demuxer directly (the #101 stream, ids with quotes and multi-byte characters, every chunk split point, UTF-8 hold-back, stray `\x1f` bytes, a random-bytes fuzz that checks nothing is lost and nothing throws). `test/test_output.jl` gains an end-to-end item — `unicode output ✔` in `BasicPackage`, whose id therefore ends in `✔` like the report's crash site — that prints a 100,000-character `✔` line so a pipe read really does split a character, and checks the output is complete, valid UTF-8 and attributed to the right item.

## Verification

Full suite via the workspace test runner: 239/239 test items pass on Julia 1.12 / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
